### PR TITLE
Misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ peers.
 For now, IBD is done from a single peer, selected from the DNS seed nodes. If the
 connection to this peer happens to fail for some reason, a new peer will be selected.
 A direct connection can also be selected from the command line. See `--help` for
-this. If the connection fails, the users has to restart and retry manually for
-now.
+this.
 
 To run on e.g. signet:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,6 @@ fn run(
             };
             let mut peer = match peer {
                 Ok(connection) => {
-                    info!("Connection established.");
                     let mut writer_lock = writer.lock().unwrap();
                     *writer_lock = Some(connection.writer());
                     connection
@@ -350,7 +349,9 @@ fn main() {
 
     info!("Bitcoin kernel initialized");
 
-    let connect: Option<SocketAddr> = config.connect.map(|sock| sock.parse().unwrap());
+    let connect = config
+        .connect
+        .map(|sock| sock.parse::<SocketAddr>().unwrap());
 
     if shutdown_rx.try_recv().is_ok() {
         info!("Shutting down!");


### PR DESCRIPTION
1. Update the `README` to reflect the user does not need manual intervention on failed connections. I somehow missed this sentence.
2. Use `parse` with a turbofish instead of declaring the type of `connect`
3. Remove a duplicate connection log.