### PR TITLE
Move node logic into dedicated binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ configure_me_codegen = "0.4.0"
 
 [package.metadata.configure_me]
 spec = "config_spec.toml"
+
+[[bin]]
+name = "node"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ this.
 To run on e.g. signet:
 
 ```
-cargo run --bin kernel-node -- --network signet
+cargo run --bin node --release -- --network signet
 ```
 
 By default it will put data in the `$HOME/kernel-node` directory.

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -10,21 +10,18 @@ use std::{
     time::Duration,
 };
 
-pub mod kernel_util;
-mod peer;
-
 use bitcoin::{BlockHash, Network};
 use bitcoinkernel::{
     ChainType, ChainstateManager, ChainstateManagerOptions, Context, ContextBuilder, Log, Logger,
     SynchronizationState, ValidationMode,
 };
-use kernel_util::{bitcoin_block_to_kernel_block, ChainExt, DirnameExt};
+use kernel_node::kernel_util::{ChainExt, DirnameExt};
 use log::{debug, error, info, warn};
 use p2p::{
     dns::DnsQueryExt,
     p2p_message_types::{address::AddrV2, message::AddrV2Payload, NetworkExt, ServiceFlags},
 };
-use peer::{BitcoinPeer, NodeState, TipState};
+use kernel_node::peer::{BitcoinPeer, NodeState, TipState};
 
 const TABLE_WIDTH: usize = 16;
 const TABLE_SLOT: usize = 16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod peer;
+pub mod kernel_util;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -19,7 +19,7 @@ use p2p::{
     },
 };
 
-use crate::bitcoin_block_to_kernel_block;
+use crate::kernel_util::bitcoin_block_to_kernel_block;
 
 const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::INVALID_CB_NO_BAN_VERSION;
 


### PR DESCRIPTION
This formalizes the node as a separate process and allows for new binaries, i.e. a client to stay in `bin`. I took the liberty of abreviating `kernel-node` as `node`.