### PR TITLE
Implement `Default` on `TipState`

### DIFF
--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -16,12 +16,12 @@ use bitcoinkernel::{
     SynchronizationState, ValidationMode,
 };
 use kernel_node::kernel_util::{ChainExt, DirnameExt};
+use kernel_node::peer::{BitcoinPeer, NodeState, TipState};
 use log::{debug, error, info, warn};
 use p2p::{
     dns::DnsQueryExt,
     p2p_message_types::{address::AddrV2, message::AddrV2Payload, NetworkExt, ServiceFlags},
 };
-use kernel_node::peer::{BitcoinPeer, NodeState, TipState};
 
 const TABLE_WIDTH: usize = 16;
 const TABLE_SLOT: usize = 16;
@@ -306,9 +306,7 @@ fn main() {
     });
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
 
-    let tip_state = Arc::new(Mutex::new(TipState {
-        block_hash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
-    }));
+    let tip_state = Arc::new(Mutex::new(TipState::default()));
 
     let network = config.network.parse::<Network>().expect("invalid network");
     let context = create_context(network.chain_type(), shutdown_tx.clone(), &tip_state);

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{mpsc, Arc, Mutex},
 };
 
-use bitcoin::Network;
+use bitcoin::{BlockHash, Network};
 use bitcoinkernel::{ChainstateManager, Context};
 use log::{debug, info};
 use p2p::{
@@ -26,6 +26,14 @@ const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::INVALID_CB_NO_BAN_VER
 #[derive(Clone)]
 pub struct TipState {
     pub block_hash: bitcoin::BlockHash,
+}
+
+impl Default for TipState {
+    fn default() -> Self {
+        Self {
+            block_hash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+        }
+    }
 }
 
 pub struct NodeState {


### PR DESCRIPTION
Removes a bit of boiler plate from the `node` binary.