### PR TITLE
Clean up DNS seeder log

### DIFF
--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -161,10 +161,7 @@ fn run(
         }
         None => {
             let addresses = resolve_seeds(network);
-            info!(
-                "These are the resolved addresses from the dns seeds: {:?}",
-                addresses
-            );
+            info!("{} addresses resolved from the dns seeds", addresses.len());
             for addr in &addresses {
                 let record = match addr {
                     IpAddr::V4(ipv4) => addrman::Record::new(


### PR DESCRIPTION
The list of resolved seeds, especially on mainnet, is particularly noisy.