### PR TITLE
Use DNS resolution from `tokio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-p2p"
 version = "0.1.0"
-source = "git+https://github.com/2140-dev/bitcoin-p2p.git?rev=a12f3372982efb62cbee8c6af8938343541c6d06#a12f3372982efb62cbee8c6af8938343541c6d06"
+source = "git+https://github.com/2140-dev/bitcoin-p2p.git?rev=322c4abb2a947f3f2d85991a0cb450249c68c1ea#322c4abb2a947f3f2d85991a0cb450249c68c1ea"
 dependencies = [
  "bitcoin",
  "bitcoin-p2p-messages",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 bitcoinkernel = "0.0.23"
 addrman = { package = "bitcoin-address-book", git = "https://github.com/rustaceanrob/bitcoin-address-book", rev = "4417e4c8f5d04245947c758b73fb0dc9e7e0bd15" }
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", default-features = false, rev = "16cc257c3695dea0e7301a5fa9cab44b8ed60598" }
-p2p = { package = "bitcoin-p2p", git =  "https://github.com/2140-dev/bitcoin-p2p.git", rev = "a12f3372982efb62cbee8c6af8938343541c6d06" }
+p2p = { package = "bitcoin-p2p", git =  "https://github.com/2140-dev/bitcoin-p2p.git", rev = "322c4abb2a947f3f2d85991a0cb450249c68c1ea" }
 ## Log and configuration
 configure_me = "0.4.0"
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
It was raised to me that the `bitcoin-p2p` DNS resolution does not work when using a VPN. Of course, this will not be acceptable for many users. With the introduction of an IPC interface, we brought in `tokio`, so we can leverage their implementation of DNS resolution. AFICT this resolves the issue.