### PR TITLE
docs: update docs default data location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run on e.g. signet:
 cargo run --bin node --release -- --network signet
 ```
 
-By default it will put data in the `$HOME/kernel-node` directory.
+By default it will put data in the `$HOME/.kernel-node` directory.
 
 Options: 
 


### PR DESCRIPTION
`config_spec.toml` contains a different data location than what's mentioned in the docs.

This is very cool btw.  It appears to be downloading testnet4 blocks onto my machine currently :)