### PR TITLE
Add end-to-end sync tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,25 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
+name = "addr2line"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -43,22 +58,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.11"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -66,6 +81,21 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base58ck"
@@ -84,9 +114,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bindgen"
@@ -122,7 +152,7 @@ dependencies = [
  "bitcoin-units",
  "bitcoin_hashes 0.16.0",
  "bitcoinconsensus",
- "hex-conservative 0.3.2",
+ "hex-conservative 0.3.0",
  "secp256k1",
 ]
 
@@ -140,14 +170,14 @@ name = "bitcoin-internals"
 version = "0.4.0"
 source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
 dependencies = [
- "hex-conservative 0.3.2",
+ "hex-conservative 0.3.0",
 ]
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 
 [[package]]
 name = "bitcoin-io"
@@ -177,7 +207,7 @@ dependencies = [
  "bitcoin-io 0.2.0",
  "bitcoin-units",
  "bitcoin_hashes 0.16.0",
- "hex-conservative 0.3.2",
+ "hex-conservative 0.3.0",
 ]
 
 [[package]]
@@ -189,7 +219,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-units",
  "bitcoin_hashes 0.16.0",
- "hex-conservative 0.3.2",
+ "hex-conservative 0.3.0",
 ]
 
 [[package]]
@@ -203,12 +233,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
- "bitcoin-io 0.1.4",
- "hex-conservative 0.2.2",
+ "bitcoin-io 0.1.3",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -217,7 +247,7 @@ version = "0.16.0"
 source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
 dependencies = [
  "bitcoin-internals",
- "hex-conservative 0.3.2",
+ "hex-conservative 0.3.0",
 ]
 
 [[package]]
@@ -240,15 +270,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "capnp"
@@ -302,11 +332,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
- "find-msvc-tools",
  "shlex",
 ]
 
@@ -321,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
@@ -338,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -348,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -360,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -372,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -412,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embedded-io"
@@ -448,14 +477,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
+name = "fastrand"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fmt2io"
@@ -465,9 +494,9 @@ checksum = "6b6129284da9f7e5296cc22183a63f24300e945e297705dcc0672f7df01d62c8"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -480,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -490,15 +519,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -507,15 +536,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -524,21 +553,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -548,14 +577,15 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -563,16 +593,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "getrandom"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -582,39 +630,39 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -622,13 +670,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.17"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -639,9 +687,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -664,6 +712,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]
@@ -680,25 +729,31 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "log"
-version = "0.4.29"
+name = "linux-raw-sys"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "man"
@@ -711,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -722,14 +777,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "mio"
-version = "1.1.1"
+name = "miniz_oxide"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -741,6 +805,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -765,9 +844,15 @@ checksum = "5bddc33f680b79eaf1e2e56da792c3c2236f86985bbc3a886e8ddee17ae4d3a4"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -780,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -790,21 +875,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -833,14 +924,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -850,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -861,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roff"
@@ -872,10 +963,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "secp256k1"
@@ -883,7 +993,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.0",
  "rand",
  "secp256k1-sys",
 ]
@@ -954,18 +1064,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -976,13 +1086,27 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -996,24 +1120,25 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2209a14885b74764cce87ffa777ffa1b8ce81a3f3166c6f886b83337fe7e077f"
 dependencies = [
+ "backtrace",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1086,9 +1211,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1115,12 +1240,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.11"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "windows-sys",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1128,6 +1262,33 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1139,28 +1300,163 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
+name = "windows-targets"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.42"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ tokio-util = { version = "0.7", features = ["compat"] }
 futures = "0.3.0"
 libc = "0.2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 capnpc = "0.25"
 configure_me_codegen = "0.4.0"

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{HashSet, VecDeque},
     net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     ops::DerefMut,
     sync::{
@@ -171,7 +172,7 @@ fn resolve_seeds(network: Network) -> Vec<IpAddr> {
 fn run(
     network: Network,
     connect: Option<SocketAddr>,
-    mut node_state: NodeState,
+    node_state: NodeState,
     shutdown_rx: mpsc::Receiver<()>,
     addr_rx: mpsc::Receiver<AddrV2Payload>,
     block_rx: mpsc::Receiver<bitcoinkernel::Block>,
@@ -241,11 +242,11 @@ fn run(
                 AddrV2::Ipv4(ipv4) => BitcoinPeer::new(
                     SocketAddr::V4(SocketAddrV4::new(ipv4, port)),
                     network,
-                    &mut node_state,
+                    &node_state,
                 ),
                 AddrV2::Ipv6(ipv6) => {
                     let socket_adrr = (ipv6, port).into();
-                    BitcoinPeer::new(socket_adrr, network, &mut node_state)
+                    BitcoinPeer::new(socket_adrr, network, &node_state)
                 }
                 _ => continue,
             };
@@ -262,7 +263,7 @@ fn run(
                 }
             };
             loop {
-                if let Err(e) = peer.receive_and_process_message(&mut node_state) {
+                if let Err(e) = peer.receive_and_process_message(&node_state) {
                     match e {
                         p2p::net::Error::Io(io) => {
                             if io.kind() != std::io::ErrorKind::UnexpectedEof {
@@ -375,7 +376,7 @@ fn main() {
         );
     let chainman = Arc::new(chainman_builder.build().unwrap());
 
-    let (block_tx, block_rx) = mpsc::sync_channel(1);
+    let (block_tx, block_rx) = mpsc::sync_channel(32);
     let (addr_tx, addr_rx) = mpsc::channel();
 
     let node_state = NodeState {
@@ -384,6 +385,8 @@ fn main() {
         tip_state,
         chainman,
         context: Arc::clone(&context),
+        in_flight_blocks: Mutex::new(HashSet::new()),
+        download_queue: Mutex::new(VecDeque::new()),
     };
 
     if let Err(err) = node_state.chainman.import_blocks() {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     fmt,
     net::SocketAddr,
     sync::{mpsc, Arc, Mutex},
@@ -27,6 +27,71 @@ use crate::kernel_util::{bitcoin_block_to_kernel_block, bitcoin_header_to_kernel
 const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::INVALID_CB_NO_BAN_VERSION;
 const MAX_LOCATOR_HASHES: usize = 101;
 
+const DOWNLOAD_BATCH_SIZE: usize = 16;
+
+// No-op if the queue is already populated; multiple peers race to call this.
+fn populate_download_queue(chainman: &ChainstateManager, queue: &Mutex<VecDeque<BlockHash>>) {
+    if !queue.lock().unwrap().is_empty() {
+        return;
+    }
+    let active_height = chainman.active_chain().height();
+    let best = match chainman.best_entry() {
+        Some(entry) => entry,
+        None => return,
+    };
+    let best_height = best.height();
+    if best_height <= active_height {
+        return;
+    }
+    let count = (best_height - active_height) as usize;
+    let mut hashes = Vec::with_capacity(count);
+    let mut current = best;
+    while current.height() > active_height {
+        let hash = BlockHash::from_byte_array(current.block_hash().to_bytes());
+        hashes.push(hash);
+        match current.prev() {
+            Some(prev) => current = prev,
+            None => break,
+        }
+    }
+    hashes.reverse();
+    // Re-check: another thread may have populated the queue while we walked the chain.
+    let mut q = queue.lock().unwrap();
+    if !q.is_empty() {
+        return;
+    }
+    info!(
+        "Built download queue with {} blocks (heights {} to {})",
+        hashes.len(),
+        active_height + 1,
+        best_height
+    );
+    *q = VecDeque::from(hashes);
+}
+
+// Always locks queue first, then in_flight, to avoid deadlock.
+fn pop_download_batch(
+    queue: &Mutex<VecDeque<BlockHash>>,
+    in_flight: &Mutex<HashSet<BlockHash>>,
+    batch_size: usize,
+) -> Vec<BlockHash> {
+    let mut q = queue.lock().unwrap();
+    let mut in_flight = in_flight.lock().unwrap();
+    let mut batch = Vec::with_capacity(batch_size);
+    while batch.len() < batch_size {
+        match q.pop_front() {
+            Some(hash) => {
+                if !in_flight.contains(&hash) {
+                    in_flight.insert(hash);
+                    batch.push(hash);
+                }
+            }
+            None => break,
+        }
+    }
+    batch
+}
+
 #[derive(Clone)]
 pub struct TipState {
     pub block_hash: bitcoin::BlockHash,
@@ -46,6 +111,8 @@ pub struct NodeState {
     pub tip_state: Arc<Mutex<TipState>>,
     pub context: Arc<Context>,
     pub chainman: Arc<ChainstateManager>,
+    pub in_flight_blocks: Mutex<HashSet<BlockHash>>,
+    pub download_queue: Mutex<VecDeque<BlockHash>>,
 }
 
 impl NodeState {
@@ -63,19 +130,20 @@ impl NodeState {
 /// State Machine for setting up a connection and getting blocks from a peer
 ///
 /// ```text
-///       [*]
-///        │
-/// AwaitingHeaders
-///        ▼
-///   AwaitingInv
-///       ▲ |
-/// Block | | Inv
-///       | ▼
-///   AwaitingBlock
-///       │ ▲
-///       │ │
-///       └─┘
-///      Block
+///          [*]
+///           │
+///    AwaitingHeaders
+///      /          \
+///  (queue)     (no queue)
+///    /              \
+/// AwaitingBlock  AwaitingInv
+///    │  ▲           ▲ |
+///    │  │     Block | | Inv
+///    └──┘           | ▼
+///  (next batch)  AwaitingBlock
+///    │               │ ▲
+///    │ (queue empty)  └─┘
+///    └──> AwaitingInv
 /// ```
 #[derive(Default)]
 pub enum PeerStateMachine {
@@ -88,6 +156,9 @@ pub enum PeerStateMachine {
 pub struct AwaitingBlock {
     pub peer_inventory: HashSet<bitcoin::BlockHash>,
     pub block_buffer: HashMap<bitcoin::BlockHash /*prev */, bitcoinkernel::Block>,
+    /// Updated eagerly on each send so the buffer can drain in chain order
+    /// without waiting for kernel validation to advance the global tip.
+    pub local_tip: bitcoin::BlockHash,
 }
 
 fn build_block_locators(tip: BlockTreeEntry<'_>) -> Vec<BlockHash> {
@@ -148,7 +219,7 @@ fn create_getdata_message(block_hashes: &[bitcoin::BlockHash]) -> NetworkMessage
 pub fn process_message(
     state_machine: PeerStateMachine,
     event: NetworkMessage,
-    node_state: &mut NodeState,
+    node_state: &NodeState,
 ) -> (PeerStateMachine, Vec<NetworkMessage>) {
     // Always process the ping first as a special case.
     if let NetworkMessage::Ping(nonce) = event {
@@ -185,6 +256,23 @@ pub fn process_message(
                 }
 
                 if headers.0.len() != 2000 {
+                    populate_download_queue(&node_state.chainman, &node_state.download_queue);
+                    let batch = pop_download_batch(
+                        &node_state.download_queue,
+                        &node_state.in_flight_blocks,
+                        DOWNLOAD_BATCH_SIZE,
+                    );
+                    if !batch.is_empty() {
+                        debug!("Requesting {} blocks", batch.len());
+                        return (
+                            PeerStateMachine::AwaitingBlock(AwaitingBlock {
+                                peer_inventory: batch.iter().cloned().collect(),
+                                block_buffer: HashMap::new(),
+                                local_tip: node_state.get_tip_state().block_hash,
+                            }),
+                            vec![create_getdata_message(&batch)],
+                        );
+                    }
                     let locators = build_block_locators(node_state.chainman.active_chain().tip());
                     return (
                         PeerStateMachine::AwaitingInv,
@@ -216,14 +304,34 @@ pub fn process_message(
                     .collect();
 
                 if !block_hashes.is_empty() {
-                    debug!("Requesting {} blocks", block_hashes.len());
-                    (
-                        PeerStateMachine::AwaitingBlock(AwaitingBlock {
-                            peer_inventory: block_hashes.iter().cloned().collect(),
-                            block_buffer: HashMap::new(),
-                        }),
-                        vec![create_getdata_message(&block_hashes)],
-                    )
+                    let mut in_flight = node_state.in_flight_blocks.lock().unwrap();
+                    let claimed: Vec<bitcoin::BlockHash> = block_hashes
+                        .into_iter()
+                        .filter(|h| !in_flight.contains(h))
+                        .collect();
+                    for h in &claimed {
+                        in_flight.insert(*h);
+                    }
+                    drop(in_flight);
+
+                    if !claimed.is_empty() {
+                        debug!("Requesting {} blocks", claimed.len());
+                        (
+                            PeerStateMachine::AwaitingBlock(AwaitingBlock {
+                                peer_inventory: claimed.iter().cloned().collect(),
+                                block_buffer: HashMap::new(),
+                                local_tip: node_state.get_tip_state().block_hash,
+                            }),
+                            vec![create_getdata_message(&claimed)],
+                        )
+                    } else {
+                        let locators =
+                            build_block_locators(node_state.chainman.active_chain().tip());
+                        (
+                            PeerStateMachine::AwaitingInv,
+                            vec![create_getblocks_message(locators)],
+                        )
+                    }
                 } else {
                     (PeerStateMachine::AwaitingInv, vec![])
                 }
@@ -236,32 +344,56 @@ pub fn process_message(
         PeerStateMachine::AwaitingBlock(mut block_state) => match event {
             NetworkMessage::Block(block) => {
                 let block = block.assume_checked(None);
+                let block_hash = block.block_hash();
                 let prev_blockhash = block.header().prev_blockhash;
-                block_state.peer_inventory.remove(&block.block_hash());
+                block_state.peer_inventory.remove(&block_hash);
+                node_state
+                    .in_flight_blocks
+                    .lock()
+                    .unwrap()
+                    .remove(&block_hash);
                 block_state
                     .block_buffer
                     .insert(prev_blockhash, bitcoin_block_to_kernel_block(&block));
 
-                while let Some(next_block) = block_state
-                    .block_buffer
-                    .remove(&node_state.get_tip_state().block_hash)
+                while let Some(next_block) = block_state.block_buffer.remove(&block_state.local_tip)
                 {
+                    let next_hash = BlockHash::from_byte_array(next_block.hash().into());
+                    block_state.local_tip = next_hash;
                     if let Err(err) = node_state.block_tx.send(next_block) {
                         debug!("Encountered error on block send: {}", err);
                         return (PeerStateMachine::AwaitingBlock(block_state), vec![]);
                     }
                 }
 
-                // If all to be expected blocks were received, clear any
-                // remaining blocks in the buffer and request a fresh batch of
-                // blocks.
                 if block_state.peer_inventory.is_empty() {
-                    block_state.block_buffer.clear();
-                    let locators = build_block_locators(node_state.chainman.active_chain().tip());
-                    (
-                        PeerStateMachine::AwaitingInv,
-                        vec![create_getblocks_message(locators)],
-                    )
+                    debug_assert!(
+                        block_state.block_buffer.is_empty(),
+                        "block_buffer should be fully drained when peer_inventory empties"
+                    );
+                    let batch = pop_download_batch(
+                        &node_state.download_queue,
+                        &node_state.in_flight_blocks,
+                        DOWNLOAD_BATCH_SIZE,
+                    );
+                    if !batch.is_empty() {
+                        debug!("Requesting {} blocks", batch.len());
+                        (
+                            PeerStateMachine::AwaitingBlock(AwaitingBlock {
+                                peer_inventory: batch.iter().cloned().collect(),
+                                block_buffer: HashMap::new(),
+                                local_tip: block_state.local_tip,
+                            }),
+                            vec![create_getdata_message(&batch)],
+                        )
+                    } else {
+                        let locators =
+                            build_block_locators(node_state.chainman.active_chain().tip());
+                        (
+                            PeerStateMachine::AwaitingInv,
+                            vec![create_getblocks_message(locators)],
+                        )
+                    }
                 } else {
                     (PeerStateMachine::AwaitingBlock(block_state), vec![])
                 }
@@ -291,7 +423,7 @@ impl BitcoinPeer {
     pub fn new(
         socket_addr: SocketAddr,
         network: Network,
-        node_state: &mut NodeState,
+        node_state: &NodeState,
     ) -> Result<Self, p2p::net::Error> {
         let height = node_state.chainman.active_chain().height();
         let conf = ConnectionConfig::new()
@@ -330,7 +462,7 @@ impl BitcoinPeer {
 
     pub fn receive_and_process_message(
         &mut self,
-        node_state: &mut NodeState,
+        node_state: &NodeState,
     ) -> Result<(), p2p::net::Error> {
         let msg = self.receive_message()?;
         let old_state = std::mem::take(&mut self.state_machine);
@@ -340,5 +472,316 @@ impl BitcoinPeer {
             self.writer.send_message(message)?
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(n: u8) -> BlockHash {
+        BlockHash::from_byte_array([n; 32])
+    }
+
+    #[test]
+    fn pop_download_batch_returns_requested_count() {
+        let queue = Mutex::new(VecDeque::from(vec![hash(1), hash(2), hash(3), hash(4)]));
+        let in_flight = Mutex::new(HashSet::new());
+        let batch = pop_download_batch(&queue, &in_flight, 2);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0], hash(1));
+        assert_eq!(batch[1], hash(2));
+        assert_eq!(queue.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn pop_download_batch_marks_in_flight() {
+        let queue = Mutex::new(VecDeque::from(vec![hash(1), hash(2)]));
+        let in_flight = Mutex::new(HashSet::new());
+        pop_download_batch(&queue, &in_flight, 2);
+        let set = in_flight.lock().unwrap();
+        assert!(set.contains(&hash(1)));
+        assert!(set.contains(&hash(2)));
+    }
+
+    #[test]
+    fn pop_download_batch_skips_already_in_flight() {
+        let queue = Mutex::new(VecDeque::from(vec![hash(1), hash(2), hash(3)]));
+        let in_flight = Mutex::new(HashSet::from([hash(2)]));
+        let batch = pop_download_batch(&queue, &in_flight, 3);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0], hash(1));
+        assert_eq!(batch[1], hash(3));
+    }
+
+    #[test]
+    fn pop_download_batch_returns_partial_when_queue_short() {
+        let queue = Mutex::new(VecDeque::from(vec![hash(1)]));
+        let in_flight = Mutex::new(HashSet::new());
+        let batch = pop_download_batch(&queue, &in_flight, 16);
+        assert_eq!(batch.len(), 1);
+        assert!(queue.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pop_download_batch_returns_empty_when_queue_empty() {
+        let queue = Mutex::new(VecDeque::new());
+        let in_flight = Mutex::new(HashSet::new());
+        let batch = pop_download_batch(&queue, &in_flight, 16);
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn pop_download_batch_returns_empty_when_all_in_flight() {
+        let queue = Mutex::new(VecDeque::from(vec![hash(1), hash(2)]));
+        let in_flight = Mutex::new(HashSet::from([hash(1), hash(2)]));
+        let batch = pop_download_batch(&queue, &in_flight, 16);
+        assert!(batch.is_empty());
+        assert!(queue.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pop_download_batch_multiple_calls_drain_queue() {
+        let queue = Mutex::new(VecDeque::from(vec![hash(1), hash(2), hash(3), hash(4)]));
+        let in_flight = Mutex::new(HashSet::new());
+        let batch1 = pop_download_batch(&queue, &in_flight, 2);
+        let batch2 = pop_download_batch(&queue, &in_flight, 2);
+        let batch3 = pop_download_batch(&queue, &in_flight, 2);
+        assert_eq!(batch1, vec![hash(1), hash(2)]);
+        assert_eq!(batch2, vec![hash(3), hash(4)]);
+        assert!(batch3.is_empty());
+    }
+
+    #[test]
+    fn pop_download_batch_preserves_fifo_order() {
+        let queue = Mutex::new(VecDeque::from(vec![
+            hash(1),
+            hash(2),
+            hash(3),
+            hash(4),
+            hash(5),
+        ]));
+        let in_flight = Mutex::new(HashSet::new());
+        let batch = pop_download_batch(&queue, &in_flight, 5);
+        assert_eq!(batch, vec![hash(1), hash(2), hash(3), hash(4), hash(5)]);
+    }
+
+    use bitcoinkernel::{ChainType, ChainstateManagerBuilder, ContextBuilder};
+    use p2p::p2p_message_types::message::HeadersMessage;
+    use tempfile::TempDir;
+
+    // encode/decode strips the BlockChecked marker, matching NetworkMessage::Block<Unchecked>.
+    fn regtest_genesis_unchecked() -> bitcoin::Block {
+        let checked = bitcoin::blockdata::constants::genesis_block(Network::Regtest);
+        let bytes = bitcoin::consensus::serialize(&checked);
+        bitcoin::consensus::deserialize(&bytes).unwrap()
+    }
+
+    // Caller must keep block_rx alive; dropping it makes block_tx.send() fail
+    // and causes process_message to exit AwaitingBlock early.
+    fn setup_regtest() -> (
+        TempDir,
+        Arc<NodeState>,
+        mpsc::Receiver<bitcoinkernel::Block>,
+    ) {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let data_dir = tmp.path().join("data");
+        let blocks_dir = tmp.path().join("blocks");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(&blocks_dir).unwrap();
+
+        let context = Arc::new(
+            ContextBuilder::new()
+                .chain_type(ChainType::Regtest)
+                .build()
+                .expect("failed to build regtest context"),
+        );
+
+        let chainman = Arc::new(
+            ChainstateManagerBuilder::new(
+                &context,
+                data_dir.to_str().unwrap(),
+                blocks_dir.to_str().unwrap(),
+            )
+            .expect("failed to create chainstate manager builder")
+            .build()
+            .expect("failed to build chainstate manager"),
+        );
+
+        chainman.import_blocks().expect("failed to import blocks");
+
+        let (block_tx, block_rx) = mpsc::sync_channel(32);
+        let (addr_tx, _addr_rx) = mpsc::channel();
+        let tip_hash =
+            BlockHash::from_byte_array(chainman.active_chain().tip().block_hash().to_bytes());
+
+        let node_state = Arc::new(NodeState {
+            addr_tx,
+            block_tx,
+            tip_state: Arc::new(Mutex::new(TipState {
+                block_hash: tip_hash,
+            })),
+            context,
+            chainman,
+            in_flight_blocks: Mutex::new(HashSet::new()),
+            download_queue: Mutex::new(VecDeque::new()),
+        });
+
+        (tmp, node_state, block_rx)
+    }
+
+    #[test]
+    fn regtest_initial_chain_state() {
+        let (_tmp, node_state, _block_rx) = setup_regtest();
+        let height = node_state.chainman.active_chain().height();
+        assert_eq!(height, 0, "regtest should start at height 0");
+        assert!(node_state.download_queue.lock().unwrap().is_empty());
+        assert!(node_state.in_flight_blocks.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn regtest_empty_headers_completes_sync() {
+        let (_tmp, node_state, _block_rx) = setup_regtest();
+        let (state, messages) = process_message(
+            PeerStateMachine::AwaitingHeaders,
+            NetworkMessage::Headers(HeadersMessage(vec![])),
+            &node_state,
+        );
+        assert!(matches!(state, PeerStateMachine::AwaitingInv));
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0], NetworkMessage::GetBlocks(_)));
+    }
+
+    #[test]
+    fn regtest_inv_deduplication() {
+        let (_tmp, node_state, _block_rx) = setup_regtest();
+        let (state, _) = process_message(
+            PeerStateMachine::AwaitingHeaders,
+            NetworkMessage::Headers(HeadersMessage(vec![])),
+            &node_state,
+        );
+        assert!(matches!(state, PeerStateMachine::AwaitingInv));
+
+        let genesis = bitcoin::blockdata::constants::genesis_block(Network::Regtest);
+        let genesis_hash = genesis.header().block_hash();
+        let inv = NetworkMessage::Inv(InventoryPayload(vec![Inventory::Block(genesis_hash)]));
+        let (state, messages) = process_message(state, inv, &node_state);
+        assert!(node_state
+            .in_flight_blocks
+            .lock()
+            .unwrap()
+            .contains(&genesis_hash));
+        assert!(matches!(state, PeerStateMachine::AwaitingBlock(_)));
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0], NetworkMessage::GetData(_)));
+
+        let inv2 = NetworkMessage::Inv(InventoryPayload(vec![Inventory::Block(genesis_hash)]));
+        let (state2, messages2) = process_message(PeerStateMachine::AwaitingInv, inv2, &node_state);
+        assert!(matches!(state2, PeerStateMachine::AwaitingInv));
+        assert_eq!(messages2.len(), 1);
+        assert!(matches!(messages2[0], NetworkMessage::GetBlocks(_)));
+    }
+
+    #[test]
+    fn local_tip_advances_on_block_receipt() {
+        let (_tmp, node_state, _block_rx) = setup_regtest();
+        let genesis_checked = bitcoin::blockdata::constants::genesis_block(Network::Regtest);
+        let genesis_hash = genesis_checked.header().block_hash();
+        let prev_hash = genesis_checked.header().prev_blockhash;
+        let genesis = regtest_genesis_unchecked();
+
+        // Two-item inventory keeps peer_inventory non-empty after genesis so local_tip can be inspected.
+        let state = PeerStateMachine::AwaitingBlock(AwaitingBlock {
+            peer_inventory: HashSet::from([genesis_hash, hash(99)]),
+            block_buffer: HashMap::new(),
+            local_tip: prev_hash,
+        });
+
+        let (new_state, messages) =
+            process_message(state, NetworkMessage::Block(genesis), &node_state);
+
+        assert!(
+            messages.is_empty(),
+            "no outbound messages while batch still incomplete"
+        );
+        match new_state {
+            PeerStateMachine::AwaitingBlock(ref ab) => {
+                assert_eq!(
+                    ab.local_tip, genesis_hash,
+                    "local_tip must advance to the received block's hash"
+                );
+                assert_eq!(ab.peer_inventory.len(), 1);
+                assert!(ab.peer_inventory.contains(&hash(99)));
+                assert!(
+                    ab.block_buffer.is_empty(),
+                    "buffer must be empty after drain"
+                );
+            }
+            _ => panic!("expected AwaitingBlock"),
+        }
+    }
+
+    #[test]
+    fn block_buffer_empty_when_batch_completes() {
+        let (_tmp, node_state, _block_rx) = setup_regtest();
+        let genesis_checked = bitcoin::blockdata::constants::genesis_block(Network::Regtest);
+        let genesis_hash = genesis_checked.header().block_hash();
+        let prev_hash = genesis_checked.header().prev_blockhash;
+        let genesis = regtest_genesis_unchecked();
+
+        let state = PeerStateMachine::AwaitingBlock(AwaitingBlock {
+            peer_inventory: HashSet::from([genesis_hash]),
+            block_buffer: HashMap::new(),
+            local_tip: prev_hash,
+        });
+
+        let (new_state, messages) =
+            process_message(state, NetworkMessage::Block(genesis), &node_state);
+
+        assert!(
+            matches!(new_state, PeerStateMachine::AwaitingInv),
+            "empty queue should transition to AwaitingInv"
+        );
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0], NetworkMessage::GetBlocks(_)));
+    }
+
+    #[test]
+    fn local_tip_carried_into_next_batch() {
+        let (_tmp, node_state, _block_rx) = setup_regtest();
+        let genesis_checked = bitcoin::blockdata::constants::genesis_block(Network::Regtest);
+        let genesis_hash = genesis_checked.header().block_hash();
+        let prev_hash = genesis_checked.header().prev_blockhash;
+        let genesis = regtest_genesis_unchecked();
+
+        // Seed queue so inventory exhaustion transitions to AwaitingBlock, not AwaitingInv.
+        let fake_next = hash(42);
+        node_state
+            .download_queue
+            .lock()
+            .unwrap()
+            .push_back(fake_next);
+
+        let state = PeerStateMachine::AwaitingBlock(AwaitingBlock {
+            peer_inventory: HashSet::from([genesis_hash]),
+            block_buffer: HashMap::new(),
+            local_tip: prev_hash,
+        });
+
+        let (new_state, messages) =
+            process_message(state, NetworkMessage::Block(genesis), &node_state);
+
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0], NetworkMessage::GetData(_)));
+        match new_state {
+            PeerStateMachine::AwaitingBlock(ref ab) => {
+                assert_eq!(
+                    ab.local_tip, genesis_hash,
+                    "local_tip must carry forward from the previous batch, not reset to the global tip"
+                );
+                assert!(ab.peer_inventory.contains(&fake_next));
+            }
+            _ => panic!("expected AwaitingBlock with next batch"),
+        }
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,426 @@
+//! End-to-end test: sync blocks from a regtest bitcoind.
+//!
+//! Requires `bitcoind` and `bitcoin-cli` in PATH.
+//! Run with: cargo test --test e2e -- --ignored --nocapture
+
+use std::{
+    collections::{HashSet, VecDeque},
+    net::{SocketAddr, TcpListener},
+    process::{Child, Command, Stdio},
+    sync::{mpsc, Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+// On macOS bind(0) assigns ephemeral ports (>=49152) which the OS can
+// reclaim before bitcoind binds. Fall back to probing the registered range.
+fn available_port() -> u16 {
+    let port = TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    if port < 49152 {
+        return port;
+    }
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    Instant::now().hash(&mut hasher);
+    let mut port = (hasher.finish() % 39152 + 10000) as u16;
+    for _ in 0..100 {
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+        port = if port >= 49151 { 10000 } else { port + 1 };
+    }
+    panic!("could not find a free port in 10000..49151");
+}
+
+use bitcoin::{BlockHash, Network};
+use bitcoinkernel::{
+    prelude::BlockValidationStateExt, ChainType, ChainstateManager, ChainstateManagerBuilder,
+    Context, ContextBuilder, ValidationMode,
+};
+use kernel_node::peer::{BitcoinPeer, NodeState, TipState};
+use tempfile::TempDir;
+
+const SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct BitcoindInstance {
+    process: Child,
+    datadir: String,
+    p2p_port: u16,
+    rpc_port: u16,
+}
+
+impl BitcoindInstance {
+    fn start(datadir: &str) -> Self {
+        let p2p_port = available_port();
+        let rpc_port = available_port();
+
+        let process = Command::new("bitcoind")
+            .args([
+                "-regtest",
+                &format!("-datadir={}", datadir),
+                &format!("-port={}", p2p_port),
+                &format!("-rpcport={}", rpc_port),
+                "-server=1",
+                "-listen=1",
+                "-listenonion=0",
+                "-txindex=0",
+                "-dnsseed=0",
+                "-fixedseeds=0",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to start bitcoind - is it in PATH?");
+
+        let mut instance = BitcoindInstance {
+            process,
+            datadir: datadir.to_string(),
+            p2p_port,
+            rpc_port,
+        };
+        instance.wait_ready();
+        instance
+    }
+
+    fn cli(&self, args: &[&str]) -> String {
+        let output = Command::new("bitcoin-cli")
+            .args([
+                "-regtest",
+                &format!("-datadir={}", self.datadir),
+                &format!("-rpcport={}", self.rpc_port),
+            ])
+            .args(args)
+            .output()
+            .expect("failed to run bitcoin-cli");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn wait_ready(&mut self) {
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(30) {
+            if let Ok(Some(status)) = self.process.try_wait() {
+                let mut stderr = String::new();
+                if let Some(ref mut s) = self.process.stderr {
+                    use std::io::Read;
+                    let _ = s.read_to_string(&mut stderr);
+                }
+                panic!("bitcoind exited with {}.\n{}", status, stderr.trim());
+            }
+            let result = self.cli(&["getblockchaininfo"]);
+            if result.contains("\"blocks\"") {
+                return;
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+        panic!("bitcoind did not become ready within 30 seconds");
+    }
+
+    fn height(&self) -> i32 {
+        self.cli(&["getblockcount"])
+            .parse()
+            .expect("failed to parse block count")
+    }
+
+    fn p2p_addr(&self) -> SocketAddr {
+        format!("127.0.0.1:{}", self.p2p_port).parse().unwrap()
+    }
+
+    fn stop(mut self) -> String {
+        let _ = self.cli(&["stop"]);
+        let _ = self.process.wait();
+        let datadir = self.datadir.clone();
+        self.datadir.clear();
+        datadir
+    }
+}
+
+impl Drop for BitcoindInstance {
+    fn drop(&mut self) {
+        if !self.datadir.is_empty() {
+            let _ = self.cli(&["stop"]);
+            let _ = self.process.wait();
+        }
+    }
+}
+
+fn has_bitcoind() -> bool {
+    Command::new("bitcoind")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+struct KernelNode {
+    tip_state: Arc<Mutex<TipState>>,
+    context: Arc<Context>,
+    chainman: Arc<ChainstateManager>,
+}
+
+impl KernelNode {
+    fn new(data_dir: &TempDir) -> Self {
+        let data_path = data_dir.path().join("data");
+        let blocks_path = data_dir.path().join("blocks");
+        std::fs::create_dir_all(&data_path).unwrap();
+        std::fs::create_dir_all(&blocks_path).unwrap();
+
+        let tip_state = Arc::new(Mutex::new(TipState::default()));
+        let tip_state_cb = Arc::clone(&tip_state);
+
+        let context = Arc::new(
+            ContextBuilder::new()
+                .chain_type(ChainType::Regtest)
+                .with_block_checked_validation(
+                    move |block: bitcoinkernel::Block,
+                          state: bitcoinkernel::BlockValidationStateRef<'_>| {
+                        if state.mode() == ValidationMode::Valid {
+                            let hash = BlockHash::from_byte_array(block.hash().into());
+                            tip_state_cb.lock().unwrap().block_hash = hash;
+                        }
+                    },
+                )
+                .build()
+                .expect("failed to build context"),
+        );
+
+        let chainman = Arc::new(
+            ChainstateManagerBuilder::new(
+                &context,
+                data_path.to_str().unwrap(),
+                blocks_path.to_str().unwrap(),
+            )
+            .expect("failed to create chainstate manager builder")
+            .build()
+            .expect("failed to build chainstate manager"),
+        );
+        chainman.import_blocks().expect("failed to import blocks");
+
+        KernelNode {
+            tip_state,
+            context,
+            chainman,
+        }
+    }
+
+    fn height(&self) -> i32 {
+        self.chainman.active_chain().height()
+    }
+}
+
+fn sync_to(node: &KernelNode, bitcoind: &BitcoindInstance, target_height: i32) {
+    let (block_tx, block_rx) = mpsc::sync_channel(32);
+    let (addr_tx, _addr_rx) = mpsc::channel();
+
+    let node_state = NodeState {
+        addr_tx,
+        block_tx,
+        tip_state: Arc::clone(&node.tip_state),
+        context: Arc::clone(&node.context),
+        chainman: Arc::clone(&node.chainman),
+        in_flight_blocks: Mutex::new(HashSet::new()),
+        download_queue: Mutex::new(VecDeque::new()),
+    };
+
+    let mut peer = BitcoinPeer::new(bitcoind.p2p_addr(), Network::Regtest, &node_state)
+        .expect("failed to connect to bitcoind");
+    eprintln!("connected to bitcoind");
+
+    let chainman_block = Arc::clone(&node.chainman);
+    let block_processor = thread::spawn(move || {
+        while let Ok(block) = block_rx.recv() {
+            chainman_block.process_block(&block);
+        }
+    });
+
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > SYNC_TIMEOUT {
+            break;
+        }
+        if let Err(e) = peer.receive_and_process_message(&node_state) {
+            eprintln!("peer disconnected: {}", e);
+            break;
+        }
+        if node.chainman.active_chain().height() >= target_height {
+            eprintln!("synced to height {}", target_height);
+            break;
+        }
+    }
+
+    drop(node_state);
+    let _ = block_processor.join();
+}
+
+#[test]
+#[ignore]
+fn e2e_sync_regtest_blocks() {
+    if !has_bitcoind() {
+        eprintln!("SKIPPED: bitcoind not found in PATH");
+        return;
+    }
+
+    let bitcoind_dir = TempDir::new().expect("failed to create temp dir");
+    let bitcoind = BitcoindInstance::start(bitcoind_dir.path().to_str().unwrap());
+    eprintln!(
+        "bitcoind started on p2p={} rpc={}",
+        bitcoind.p2p_port, bitcoind.rpc_port
+    );
+
+    bitcoind.cli(&["createwallet", "test"]);
+    let address = bitcoind.cli(&["getnewaddress"]);
+    bitcoind.cli(&["generatetoaddress", "150", &address]);
+    assert_eq!(bitcoind.height(), 150);
+    eprintln!("mined 150 blocks");
+
+    let node_dir = TempDir::new().expect("failed to create temp dir");
+    let node = KernelNode::new(&node_dir);
+
+    sync_to(&node, &bitcoind, 150);
+
+    assert_eq!(
+        node.height(),
+        150,
+        "kernel-node should have synced to height 150",
+    );
+}
+
+#[test]
+#[ignore]
+fn e2e_sync_resume() {
+    if !has_bitcoind() {
+        eprintln!("SKIPPED: bitcoind not found in PATH");
+        return;
+    }
+
+    let bitcoind_dir = TempDir::new().expect("failed to create temp dir");
+    let bitcoind = BitcoindInstance::start(bitcoind_dir.path().to_str().unwrap());
+    eprintln!(
+        "bitcoind started on p2p={} rpc={}",
+        bitcoind.p2p_port, bitcoind.rpc_port
+    );
+
+    bitcoind.cli(&["createwallet", "test"]);
+    let address = bitcoind.cli(&["getnewaddress"]);
+
+    bitcoind.cli(&["generatetoaddress", "50", &address]);
+    assert_eq!(bitcoind.height(), 50);
+    eprintln!("phase 1: mined 50 blocks");
+
+    let node_dir = TempDir::new().expect("failed to create temp dir");
+    let node = KernelNode::new(&node_dir);
+    sync_to(&node, &bitcoind, 50);
+    assert_eq!(node.height(), 50, "should have synced to height 50");
+    eprintln!("phase 1: synced to height {}", node.height());
+
+    bitcoind.cli(&["generatetoaddress", "50", &address]);
+    assert_eq!(bitcoind.height(), 100);
+    eprintln!("phase 2: mined 50 more blocks (total 100)");
+
+    sync_to(&node, &bitcoind, 100);
+    assert_eq!(
+        node.height(),
+        100,
+        "kernel-node should have resumed and synced to height 100",
+    );
+    eprintln!("phase 2: synced to height {}", node.height());
+}
+
+#[test]
+#[ignore]
+fn e2e_disconnect_and_reconnect() {
+    if !has_bitcoind() {
+        eprintln!("SKIPPED: bitcoind not found in PATH");
+        return;
+    }
+
+    let bitcoind_dir = TempDir::new().expect("failed to create temp dir");
+    let datadir = bitcoind_dir.path().to_str().unwrap();
+    let bitcoind = BitcoindInstance::start(datadir);
+    eprintln!(
+        "bitcoind started on p2p={} rpc={}",
+        bitcoind.p2p_port, bitcoind.rpc_port
+    );
+
+    bitcoind.cli(&["createwallet", "test"]);
+    let address = bitcoind.cli(&["getnewaddress"]);
+    bitcoind.cli(&["generatetoaddress", "150", &address]);
+    assert_eq!(bitcoind.height(), 150);
+    eprintln!("mined 150 blocks");
+
+    let node_dir = TempDir::new().expect("failed to create temp dir");
+    let node = KernelNode::new(&node_dir);
+
+    sync_to(&node, &bitcoind, 50);
+    let partial_height = node.height();
+    assert!(
+        partial_height >= 1,
+        "should have synced at least 1 block before disconnect"
+    );
+    eprintln!("synced to height {} before disconnect", partial_height);
+
+    let datadir = bitcoind.stop();
+    eprintln!("bitcoind stopped");
+
+    let bitcoind2 = BitcoindInstance::start(&datadir);
+    eprintln!(
+        "bitcoind restarted on p2p={} rpc={}",
+        bitcoind2.p2p_port, bitcoind2.rpc_port
+    );
+    assert_eq!(bitcoind2.height(), 150);
+
+    sync_to(&node, &bitcoind2, 150);
+    assert_eq!(
+        node.height(),
+        150,
+        "kernel-node should have synced to height 150 after reconnect",
+    );
+    eprintln!("synced to height {} after reconnect", node.height());
+}
+
+#[test]
+#[ignore]
+fn e2e_mine_after_sync() {
+    if !has_bitcoind() {
+        eprintln!("SKIPPED: bitcoind not found in PATH");
+        return;
+    }
+
+    let bitcoind_dir = TempDir::new().expect("failed to create temp dir");
+    let bitcoind = BitcoindInstance::start(bitcoind_dir.path().to_str().unwrap());
+    eprintln!(
+        "bitcoind started on p2p={} rpc={}",
+        bitcoind.p2p_port, bitcoind.rpc_port
+    );
+
+    bitcoind.cli(&["createwallet", "test"]);
+    let address = bitcoind.cli(&["getnewaddress"]);
+    bitcoind.cli(&["generatetoaddress", "100", &address]);
+    assert_eq!(bitcoind.height(), 100);
+    eprintln!("mined 100 blocks");
+
+    let node_dir = TempDir::new().expect("failed to create temp dir");
+    let node = KernelNode::new(&node_dir);
+
+    sync_to(&node, &bitcoind, 100);
+    assert_eq!(node.height(), 100, "should have synced to height 100");
+    eprintln!("synced to height {}", node.height());
+
+    bitcoind.cli(&["generatetoaddress", "10", &address]);
+    assert_eq!(bitcoind.height(), 110);
+    eprintln!("mined 10 more blocks (total 110)");
+
+    sync_to(&node, &bitcoind, 110);
+    assert_eq!(
+        node.height(),
+        110,
+        "kernel-node should have picked up new blocks via getblocks/inv",
+    );
+    eprintln!("synced to height {} after new blocks mined", node.height());
+}


### PR DESCRIPTION
Verify that `BitcoinPeer` correctly syncs blocks over a live P2P connection with real consensus validation. Tests run against a local bitcoind in regtest mode.

Adds four `#[ignore]` integration tests in `tests/e2e.rs`:
`e2e_sync_regtest_blocks`: mines 150 blocks, asserts kernel-node syncs to height 150.
`e2e_sync_resume`: syncs 50 blocks, mines 50 more, reconnects, and asserts the node resumes from height 50 without re-downloading. Exercises chainstate persistence and the locator-based fork-point logic.
`e2e_disconnect_reconnect`: syncs partway, stops bitcoind, restarts it with the same datadir, and asserts sync completes to height 150.
`e2e_mine_after_sync`: syncs 100 blocks, mines 10 more, reconnects, and asserts the node picks up new blocks via the getblocks/inv path.

Helpers: 
`KernelNode` wraps Context, ChainstateManager, tip_state across reconnections
`sync_to()` drives the message loop to a target height or timeout
`BitcoindInstance.stop()` gracefully shuts down with datadir reuse.

Requires `bitcoind` and `bitcoin-cli` in PATH.