### PR TITLE
fix: Use `mode_t` type for `umask`

### DIFF
--- a/src/daemonize.rs
+++ b/src/daemonize.rs
@@ -3,7 +3,7 @@ use std::{
     os::fd::IntoRawFd,
 };
 
-const MASK_OCTAL: u32 = 0o027;
+const MASK_OCTAL: libc::mode_t = 0o027;
 const DEV_NULL: &str = "/dev/null";
 
 pub struct Daemonize {


### PR DESCRIPTION
MacOS expects a 16 bit integer here.