### PR TITLE
silent payments: integrate SPDK scanning and wallet IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "configure_me_codegen",
  "env_logger",
  "futures",
+ "hex",
  "libc",
  "log",
  "secp256k1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,14 +74,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.1",
 ]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bindgen"
@@ -110,12 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.1",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
 ]
@@ -160,12 +172,21 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446819536d8121575eeb7e89efdbadb3f055e87e4bb66c6679a6d5cc2f4b64fd"
+dependencies = [
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -526,6 +547,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +635,7 @@ dependencies = [
  "log",
  "tokio",
  "tokio-util",
+ "wallet",
 ]
 
 [[package]]
@@ -819,7 +853,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.1",
  "rand",
  "secp256k1-sys",
 ]
@@ -886,6 +920,20 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "silentpayments"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131d42e3050dd88c79e4849b27eaf0cda0625f4e910d97bf05044a1300459f85"
+dependencies = [
+ "bech32 0.9.1",
+ "bimap",
+ "bitcoin_hashes 0.13.1",
+ "hex",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -1043,6 +1091,16 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wallet"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "log",
+ "secp256k1",
+ "silentpayments",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
+ "secp256k1",
  "tokio",
  "tokio-util",
  "wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "crates/wallet"]
+resolver = "2"
+
 [package]
 name = "kernel-node"
 version = "0.1.0"
@@ -15,6 +19,7 @@ configure_me = "0.4.0"
 clap = { version = "4", features = ["derive"] }
 log = "0.4"
 env_logger = "0.10"
+wallet = { path = "crates/wallet" }
 ## IPC required dependencies
 capnp = "0.25"
 capnp-rpc = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive"] }
 log = "0.4"
 env_logger = "0.10"
 wallet = { path = "crates/wallet" }
+secp256k1 = "0.29"
 ## IPC required dependencies
 capnp = "0.25"
 capnp-rpc = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4"
 env_logger = "0.10"
 wallet = { path = "crates/wallet" }
 secp256k1 = "0.29"
+hex = "0.4"
 ## IPC required dependencies
 capnp = "0.25"
 capnp-rpc = "0.25"

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), configure_me_codegen::Error> {
     CompilerCommand::new()
         .src_prefix("capnp")
         .file("capnp/server.capnp")
+        .file("capnp/wallet.capnp")
         .run()
         .unwrap();
     configure_me_codegen::build_script_auto()

--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -1,0 +1,7 @@
+@0xb5d3a2f1e8c47690;
+
+interface Wallet {
+    importKeys @0 (scanKey :Data, spendKey :Data) -> (ok :Bool, message :Text);
+    getBalance  @1 () -> (sats :UInt64, scanHeight :UInt32, utxoCount :UInt32);
+    getHistory  @2 () -> (entries :Text);
+}

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wallet"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+silentpayments = { version = "0.5", features = ["receiving"] }
+secp256k1 = "0.29"
+bitcoin = "0.32.8"
+log = "0.4"

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod silentpayments;

--- a/crates/wallet/src/silentpayments/mod.rs
+++ b/crates/wallet/src/silentpayments/mod.rs
@@ -1,0 +1,21 @@
+mod scanning;
+mod wallet;
+
+pub use ::silentpayments::receiving::Receiver;
+pub use ::silentpayments::{Network, SilentPaymentAddress};
+pub use scanning::{scan_block, scan_transaction, FoundPayment, InputData};
+pub use wallet::{HistoryEntry, OwnedUtxo, SilentPaymentWallet, SpentBy};
+
+use ::silentpayments::receiving::Label;
+use secp256k1::{PublicKey, SecretKey};
+
+pub fn build_receiver(
+    b_scan: &SecretKey,
+    b_spend_pub: PublicKey,
+    network: Network,
+) -> Result<Receiver, ::silentpayments::Error> {
+    let secp = secp256k1::Secp256k1::signing_only();
+    let scan_pubkey = PublicKey::from_secret_key(&secp, b_scan);
+    let change_label = Label::new(*b_scan, 0);
+    Receiver::new(0, scan_pubkey, b_spend_pub, change_label, network)
+}

--- a/crates/wallet/src/silentpayments/scanning.rs
+++ b/crates/wallet/src/silentpayments/scanning.rs
@@ -1,0 +1,104 @@
+use ::silentpayments::{
+    receiving::Receiver,
+    utils::receiving::{calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input},
+};
+use bitcoin::{Block, Transaction};
+use secp256k1::{SecretKey, XOnlyPublicKey};
+
+pub struct InputData {
+    pub script_sig: Vec<u8>,
+    pub witness: Vec<Vec<u8>>,
+    pub prevout_script: Vec<u8>,
+    pub txid: String,
+    pub vout: u32,
+}
+
+pub struct FoundPayment {
+    pub output_index: usize,
+    pub pubkey: XOnlyPublicKey,
+}
+
+pub fn scan_transaction(
+    receiver: &Receiver,
+    b_scan: &SecretKey,
+    inputs: &[InputData],
+    tx: &Transaction,
+) -> Vec<FoundPayment> {
+    let mut input_pub_keys = Vec::new();
+    let mut outpoints = Vec::new();
+    for input in inputs {
+        if let Ok(Some(pk)) =
+            get_pubkey_from_input(&input.script_sig, &input.witness, &input.prevout_script)
+        {
+            input_pub_keys.push(pk);
+            outpoints.push((input.txid.clone(), input.vout));
+        }
+    }
+
+    if input_pub_keys.is_empty() {
+        return vec![];
+    }
+
+    // Silent payments always produce taproot outputs — skip transactions without any.
+    let taproot_outputs: Vec<(usize, XOnlyPublicKey)> = tx
+        .output
+        .iter()
+        .enumerate()
+        .filter_map(|(i, out)| {
+            let spk = out.script_pubkey.as_bytes();
+            if spk.len() == 34 && spk[0] == 0x51 && spk[1] == 0x20 {
+                XOnlyPublicKey::from_slice(&spk[2..]).ok().map(|pk| (i, pk))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if taproot_outputs.is_empty() {
+        return vec![];
+    }
+
+    let pubkey_refs: Vec<&secp256k1::PublicKey> = input_pub_keys.iter().collect();
+    let tweak_data = match calculate_tweak_data(&pubkey_refs, &outpoints) {
+        Ok(td) => td,
+        Err(_) => return vec![],
+    };
+    let shared_secret = calculate_ecdh_shared_secret(&tweak_data, b_scan);
+
+    let xonly_outputs: Vec<XOnlyPublicKey> = taproot_outputs.iter().map(|(_, pk)| *pk).collect();
+    let found = match receiver.scan_transaction(&shared_secret, xonly_outputs) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+
+    let mut result = Vec::new();
+    for map in found.values() {
+        for pk in map.keys() {
+            if let Some((idx, _)) = taproot_outputs.iter().find(|(_, o)| o == pk) {
+                result.push(FoundPayment {
+                    output_index: *idx,
+                    pubkey: *pk,
+                });
+            }
+        }
+    }
+    result
+}
+
+pub fn scan_block(
+    receiver: &Receiver,
+    b_scan: &SecretKey,
+    block: &Block,
+    tx_input_data: Vec<Vec<InputData>>,
+) -> Vec<(bitcoin::Txid, FoundPayment)> {
+    let mut all_found = Vec::new();
+    // Skip coinbase (index 0); tx_input_data[i] maps to block.txdata[i+1].
+    for (i, tx) in block.txdata.iter().skip(1).enumerate() {
+        if let Some(inputs) = tx_input_data.get(i) {
+            for payment in scan_transaction(receiver, b_scan, inputs, tx) {
+                all_found.push((tx.compute_txid(), payment));
+            }
+        }
+    }
+    all_found
+}

--- a/crates/wallet/src/silentpayments/wallet.rs
+++ b/crates/wallet/src/silentpayments/wallet.rs
@@ -1,0 +1,206 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{self, Read, Write},
+    path::Path,
+};
+
+use bitcoin::{hashes::Hash, Amount, Block, OutPoint, Txid};
+
+const MAGIC: &[u8; 4] = b"SP02";
+
+#[derive(Debug, Clone)]
+pub struct SpentBy {
+    pub txid: Txid,
+    pub block_height: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct OwnedUtxo {
+    pub value: Amount,
+    pub block_height: u32,
+    pub spent_by: Option<SpentBy>,
+}
+
+pub enum HistoryEntry {
+    Received {
+        outpoint: OutPoint,
+        value: Amount,
+        block_height: u32,
+    },
+    Spent {
+        outpoint: OutPoint,
+        value: Amount,
+        spent_at: u32,
+    },
+}
+
+pub struct SilentPaymentWallet {
+    pub scan_height: u32,
+    utxos: HashMap<OutPoint, OwnedUtxo>,
+}
+
+impl Default for SilentPaymentWallet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SilentPaymentWallet {
+    pub fn new() -> Self {
+        Self {
+            scan_height: 0,
+            utxos: HashMap::new(),
+        }
+    }
+
+    pub fn process_block(
+        &mut self,
+        block: &Block,
+        block_height: u32,
+        found: &[(Txid, usize, Amount)],
+    ) {
+        for (txid, vout, value) in found {
+            let outpoint = OutPoint {
+                txid: *txid,
+                vout: *vout as u32,
+            };
+            self.utxos.insert(
+                outpoint,
+                OwnedUtxo {
+                    value: *value,
+                    block_height,
+                    spent_by: None,
+                },
+            );
+        }
+
+        for tx in &block.txdata {
+            let spending_txid = tx.compute_txid();
+            for input in &tx.input {
+                if let Some(utxo) = self.utxos.get_mut(&input.previous_output) {
+                    utxo.spent_by = Some(SpentBy {
+                        txid: spending_txid,
+                        block_height,
+                    });
+                }
+            }
+        }
+
+        self.scan_height = block_height;
+    }
+
+    pub fn utxo_count(&self) -> usize {
+        self.utxos.values().filter(|u| u.spent_by.is_none()).count()
+    }
+
+    pub fn balance(&self) -> Amount {
+        self.utxos
+            .values()
+            .filter(|u| u.spent_by.is_none())
+            .map(|u| u.value)
+            .fold(Amount::ZERO, |acc, v| acc + v)
+    }
+
+    pub fn history(&self) -> Vec<HistoryEntry> {
+        let mut entries: Vec<HistoryEntry> = self
+            .utxos
+            .iter()
+            .flat_map(|(outpoint, utxo)| {
+                let mut v = vec![HistoryEntry::Received {
+                    outpoint: *outpoint,
+                    value: utxo.value,
+                    block_height: utxo.block_height,
+                }];
+                if let Some(ref s) = utxo.spent_by {
+                    v.push(HistoryEntry::Spent {
+                        outpoint: *outpoint,
+                        value: utxo.value,
+                        spent_at: s.block_height,
+                    });
+                }
+                v
+            })
+            .collect();
+
+        entries.sort_by_key(|e| match e {
+            HistoryEntry::Received { block_height, .. } => *block_height,
+            HistoryEntry::Spent { spent_at, .. } => *spent_at,
+        });
+        entries
+    }
+
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let mut f = File::create(path)?;
+        f.write_all(MAGIC)?;
+        f.write_all(&self.scan_height.to_le_bytes())?;
+        let count = self.utxos.len() as u32;
+        f.write_all(&count.to_le_bytes())?;
+        for (outpoint, utxo) in &self.utxos {
+            f.write_all(outpoint.txid.as_ref())?;
+            f.write_all(&outpoint.vout.to_le_bytes())?;
+            f.write_all(&utxo.value.to_sat().to_le_bytes())?;
+            f.write_all(&utxo.block_height.to_le_bytes())?;
+            match &utxo.spent_by {
+                None => f.write_all(&[0u8])?,
+                Some(s) => {
+                    f.write_all(&[1u8])?;
+                    f.write_all(s.txid.as_ref())?;
+                    f.write_all(&s.block_height.to_le_bytes())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn load(path: &Path) -> io::Result<Self> {
+        let mut f = File::open(path)?;
+        let mut magic = [0u8; 4];
+        f.read_exact(&mut magic)?;
+        if &magic != MAGIC {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "bad magic"));
+        }
+        let mut buf4 = [0u8; 4];
+        f.read_exact(&mut buf4)?;
+        let scan_height = u32::from_le_bytes(buf4);
+        f.read_exact(&mut buf4)?;
+        let count = u32::from_le_bytes(buf4);
+        let mut utxos = HashMap::new();
+        for _ in 0..count {
+            let mut txid_bytes = [0u8; 32];
+            f.read_exact(&mut txid_bytes)?;
+            let txid = Txid::from_byte_array(txid_bytes);
+            f.read_exact(&mut buf4)?;
+            let vout = u32::from_le_bytes(buf4);
+            let mut buf8 = [0u8; 8];
+            f.read_exact(&mut buf8)?;
+            let value = Amount::from_sat(u64::from_le_bytes(buf8));
+            f.read_exact(&mut buf4)?;
+            let block_height = u32::from_le_bytes(buf4);
+            let mut spent_flag = [0u8; 1];
+            f.read_exact(&mut spent_flag)?;
+            let spent_by = if spent_flag[0] == 1 {
+                let mut stxid_bytes = [0u8; 32];
+                f.read_exact(&mut stxid_bytes)?;
+                let stxid = Txid::from_byte_array(stxid_bytes);
+                f.read_exact(&mut buf4)?;
+                let sbh = u32::from_le_bytes(buf4);
+                Some(SpentBy {
+                    txid: stxid,
+                    block_height: sbh,
+                })
+            } else {
+                None
+            };
+            utxos.insert(
+                OutPoint { txid, vout },
+                OwnedUtxo {
+                    value,
+                    block_height,
+                    spent_by,
+                },
+            );
+        }
+        Ok(Self { scan_height, utxos })
+    }
+}

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use kernel_node::kernel_util::DirnameExt;
 use kernel_node::server_capnp::server;
+use kernel_node::wallet_capnp::wallet;
 use tokio::net::UnixStream;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -28,6 +29,9 @@ enum Commands {
     Echo(Echo),
     /// Terminate the server.
     Stop,
+    /// Wallet commands (connects to wallet.sock).
+    #[command(subcommand)]
+    Wallet(WalletCmd),
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -36,18 +40,27 @@ struct Echo {
     message: String,
 }
 
-fn main() {
-    let cli = Args::parse();
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    let datadir_path = cli.opts.datadir.unwrap_or(DEFAULT_DATA_DIR.data_dir());
-    let sock_file = datadir_path + "/node.sock";
-    rt.block_on(tokio::task::LocalSet::new().run_until(async move {
+#[derive(Debug, Clone, clap::Subcommand)]
+enum WalletCmd {
+    /// Import a scan key (hex) and spend key (hex).
+    ImportKeys {
+        /// 32-byte scan private key as hex.
+        scan_key: String,
+        /// 33-byte spend public key as hex.
+        spend_key: String,
+    },
+    /// Show wallet balance.
+    Balance,
+    /// Show wallet transaction history.
+    History,
+}
+
+async fn connect_wallet(datadir_path: &str) -> wallet::Client {
+    {
+        let sock_file = datadir_path.to_owned() + "/wallet.sock";
         let stream = UnixStream::connect(sock_file)
             .await
-            .expect("Could not connect to unix socket. Is `node` running?");
+            .expect("Could not connect to wallet.sock. Is `node` running?");
         let (reader, writer) = stream.into_split();
         let buf_reader = futures::io::BufReader::new(reader.compat());
         let buf_writer = futures::io::BufWriter::new(writer.compat_write());
@@ -58,11 +71,42 @@ fn main() {
             Default::default(),
         );
         let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
-        let client: server::Client =
+        let client: wallet::Client =
             rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
         tokio::task::spawn_local(rpc_system);
+        client
+    }
+}
+
+fn main() {
+    let cli = Args::parse();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let datadir_path = cli.opts.datadir.unwrap_or(DEFAULT_DATA_DIR.data_dir());
+
+    rt.block_on(tokio::task::LocalSet::new().run_until(async move {
         match cli.commands {
             Commands::Echo(echo) => {
+                let sock_file = datadir_path + "/node.sock";
+                let stream = UnixStream::connect(sock_file)
+                    .await
+                    .expect("Could not connect to unix socket. Is `node` running?");
+                let (reader, writer) = stream.into_split();
+                let buf_reader = futures::io::BufReader::new(reader.compat());
+                let buf_writer = futures::io::BufWriter::new(writer.compat_write());
+                let network = capnp_rpc::twoparty::VatNetwork::new(
+                    buf_reader,
+                    buf_writer,
+                    capnp_rpc::rpc_twoparty_capnp::Side::Client,
+                    Default::default(),
+                );
+                let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
+                let client: server::Client =
+                    rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+                tokio::task::spawn_local(rpc_system);
+
                 let mut echo_req = client.echo_request();
                 println!("Sending... {}", echo.message);
                 echo_req.get().set_msg(echo.message);
@@ -77,9 +121,71 @@ fn main() {
                 println!("{result}");
             }
             Commands::Stop => {
+                let sock_file = datadir_path + "/node.sock";
+                let stream = UnixStream::connect(sock_file)
+                    .await
+                    .expect("Could not connect to unix socket. Is `node` running?");
+                let (reader, writer) = stream.into_split();
+                let buf_reader = futures::io::BufReader::new(reader.compat());
+                let buf_writer = futures::io::BufWriter::new(writer.compat_write());
+                let network = capnp_rpc::twoparty::VatNetwork::new(
+                    buf_reader,
+                    buf_writer,
+                    capnp_rpc::rpc_twoparty_capnp::Side::Client,
+                    Default::default(),
+                );
+                let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
+                let client: server::Client =
+                    rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+                tokio::task::spawn_local(rpc_system);
+
                 let shutdown_req = client.shutdown_request();
                 shutdown_req.send().promise.await.unwrap();
                 println!("Kernel node stopping...");
+            }
+            Commands::Wallet(cmd) => {
+                let client = connect_wallet(&datadir_path).await;
+                match cmd {
+                    WalletCmd::ImportKeys {
+                        scan_key,
+                        spend_key,
+                    } => {
+                        let scan_bytes =
+                            hex::decode(&scan_key).expect("scan_key must be valid hex");
+                        let spend_bytes =
+                            hex::decode(&spend_key).expect("spend_key must be valid hex");
+
+                        let mut req = client.import_keys_request();
+                        req.get().set_scan_key(&scan_bytes);
+                        req.get().set_spend_key(&spend_bytes);
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let msg = r.get_message().unwrap().to_string().unwrap();
+                        println!("{}", msg);
+                    }
+                    WalletCmd::Balance => {
+                        let req = client.get_balance_request();
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        println!(
+                            "Balance: {} sats | scan height: {} | UTXOs: {}",
+                            r.get_sats(),
+                            r.get_scan_height(),
+                            r.get_utxo_count(),
+                        );
+                    }
+                    WalletCmd::History => {
+                        let req = client.get_history_request();
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let entries = r.get_entries().unwrap().to_string().unwrap();
+                        if entries.is_empty() {
+                            println!("No history yet.");
+                        } else {
+                            println!("{}", entries);
+                        }
+                    }
+                }
             }
         }
     }))

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -10,29 +10,34 @@ use std::{
     time::{Duration, Instant},
 };
 
+use bitcoin::consensus::deserialize as btc_deserialize;
 use bitcoin::p2p::{
     address::{AddrV2, AddrV2Message},
     ServiceFlags,
 };
 use bitcoin::{hashes::Hash, BlockHash, Network};
 use bitcoinkernel::{
-    core::BlockHashExt, prelude::BlockValidationStateExt, ChainType, ChainstateManagerBuilder,
-    Context, ContextBuilder, Log, Logger, SynchronizationState, ValidationMode,
+    core::BlockHashExt,
+    prelude::{
+        BlockSpentOutputsExt, BlockValidationStateExt, CoinExt, ScriptPubkeyExt,
+        TransactionSpentOutputsExt, TxOutExt,
+    },
+    ChainType, ChainstateManager, ChainstateManagerBuilder, Context, ContextBuilder, Log, Logger,
+    SynchronizationState, ValidationMode,
 };
 use kernel_node::{
     daemonize::Daemonize,
-    kernel_util::NetworkExt,
+    ipc::{IpcInterface, WalletIpcInterface, WalletState},
+    kernel_util::{ChainExt, DirnameExt, NetworkExt},
     peer::{BitcoinPeer, NodeState, TipState},
-};
-use kernel_node::{
-    ipc::IpcInterface,
-    kernel_util::{ChainExt, DirnameExt},
     server_capnp::server,
+    wallet_capnp::wallet as wallet_ipc,
 };
 use log::{debug, error, info, warn};
 use p2p::dns::{BITCOIN_SEEDS, SIGNET_SEEDS, TESTNET3_SEEDS, TESTNET4_SEEDS};
 use tokio::net::UnixListener;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use wallet::silentpayments::{build_receiver, scan_block, InputData, Network as WalletNetwork};
 
 const TABLE_WIDTH: usize = 16;
 const TABLE_SLOT: usize = 16;
@@ -43,6 +48,113 @@ const DNS_RESOLVER: IpAddr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
 const STALE_BLOCK_DURATION: Duration = Duration::from_secs(60 * 20);
 
 configure_me::include_config!();
+
+fn to_wallet_network(network: Network) -> WalletNetwork {
+    match network {
+        Network::Bitcoin => WalletNetwork::Mainnet,
+        Network::Regtest => WalletNetwork::Regtest,
+        _ => WalletNetwork::Testnet,
+    }
+}
+
+fn scan_kernel_block(
+    chainman: &ChainstateManager,
+    kernel_block: &bitcoinkernel::Block,
+    wallet_state: &WalletState,
+) {
+    let scan_key = match *wallet_state.scan_key.lock().unwrap() {
+        Some(k) => k,
+        None => return,
+    };
+    let spend_key = match *wallet_state.spend_key.lock().unwrap() {
+        Some(k) => k,
+        None => return,
+    };
+
+    let receiver = match build_receiver(&scan_key, spend_key, wallet_state.network) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("build_receiver failed: {e}");
+            return;
+        }
+    };
+
+    let entry = chainman.active_chain().tip();
+    let block_height = entry.height() as u32;
+
+    let undo = match chainman.read_spent_outputs(&entry) {
+        Ok(u) => u,
+        Err(e) => {
+            warn!("read_spent_outputs failed at height {block_height}: {e}");
+            return;
+        }
+    };
+
+    let raw = match kernel_block.consensus_encode() {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("consensus_encode failed: {e}");
+            return;
+        }
+    };
+    let btc_block: bitcoin::Block = match btc_deserialize(&raw) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("block deserialize failed: {e}");
+            return;
+        }
+    };
+
+    // undo[i] corresponds to btc_block.txdata[i+1] (coinbase has no undo entry).
+    let mut tx_input_data: Vec<Vec<InputData>> = Vec::new();
+    for (undo_idx, tx_spent) in undo.iter().enumerate() {
+        let btc_tx = match btc_block.txdata.get(undo_idx + 1) {
+            Some(t) => t,
+            None => break,
+        };
+        let mut inputs = Vec::new();
+        for (input_idx, btc_input) in btc_tx.input.iter().enumerate() {
+            if let Ok(coin) = tx_spent.coin(input_idx) {
+                inputs.push(InputData {
+                    script_sig: btc_input.script_sig.as_bytes().to_vec(),
+                    witness: btc_input.witness.iter().map(|item| item.to_vec()).collect(),
+                    prevout_script: coin.output().script_pubkey().to_bytes(),
+                    txid: btc_input.previous_output.txid.to_string(),
+                    vout: btc_input.previous_output.vout,
+                });
+            }
+        }
+        tx_input_data.push(inputs);
+    }
+
+    let payments = scan_block(&receiver, &scan_key, &btc_block, tx_input_data);
+    if payments.is_empty() {
+        return;
+    }
+
+    let found: Vec<(bitcoin::Txid, usize, bitcoin::Amount)> = payments
+        .iter()
+        .filter_map(|(txid, payment)| {
+            btc_block
+                .txdata
+                .iter()
+                .find(|tx| tx.compute_txid() == *txid)
+                .and_then(|tx| tx.output.get(payment.output_index))
+                .map(|out| (*txid, payment.output_index, out.value))
+        })
+        .collect();
+
+    wallet_state
+        .wallet
+        .lock()
+        .unwrap()
+        .process_block(&btc_block, block_height, &found);
+    info!(
+        "Wallet: found {} silent payment(s) at height {}",
+        found.len(),
+        block_height
+    );
+}
 
 fn create_context(
     chain_type: ChainType,
@@ -87,7 +199,6 @@ fn create_context(
                     shutdown_tx_clone.send(()).expect("failed to send shutdown signal");
                 }
         })
-        // .with_block_checked_validation(setup_validation_interface(tip_state))
         .with_block_checked_validation(move |block: bitcoinkernel::Block, state: bitcoinkernel::BlockValidationStateRef<'_>| {
             match state.mode() {
                 ValidationMode::Valid => {
@@ -107,7 +218,7 @@ struct KernelLog {}
 impl Log for KernelLog {
     fn log(&self, message: &str) {
         log::info!(
-            target: "bitcoinkernel", 
+            target: "bitcoinkernel",
             "{}", message.strip_suffix("\r\n").or_else(|| message.strip_suffix('\n')).unwrap_or(message));
     }
 }
@@ -122,22 +233,6 @@ fn setup_logging() {
 
     unsafe { GLOBAL_LOG_CALLBACK_HOLDER = Some(Logger::new(KernelLog {}).unwrap()) };
 }
-
-// fn setup_validation_interface(
-//     tip_state: &Arc<Mutex<TipState>>,
-// ) -> Box<ValidationInterfaceCallbacks> {
-//     let tip_state_clone = Arc::clone(&tip_state);
-//     Box::new(ValidationInterfaceCallbacks {
-//         block_checked: Box::new(move |block, mode, _result| match mode {
-//             ValidationMode::Valid => {
-//                 let hash = bitcoin::BlockHash::from_byte_array(block.get_hash().hash);
-//                 log::debug!("Validation interface: Successfully checked block: {}", hash);
-//                 tip_state_clone.lock().unwrap().block_hash = hash;
-//             }
-//             _ => error!("Received an invalid block!"),
-//         }),
-//     })
-// }
 
 fn resolve_seeds(network: Network) -> Vec<IpAddr> {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -172,6 +267,7 @@ fn run(
     shutdown_rx: mpsc::Receiver<()>,
     addr_rx: mpsc::Receiver<Vec<AddrV2Message>>,
     block_rx: mpsc::Receiver<bitcoinkernel::Block>,
+    wallet_state: WalletState,
 ) -> std::io::Result<()> {
     let mut table = addrman::Table::<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>::new();
     match connect {
@@ -305,7 +401,10 @@ fn run(
                 Ok(block) => {
                     debug!("Validating block.");
                     last_block = Instant::now();
-                    let _ = chainman.process_block(&block);
+                    let result = chainman.process_block(&block);
+                    if result.is_new_block() {
+                        scan_kernel_block(&chainman, &block, &wallet_state);
+                    }
                 }
                 Err(RecvTimeoutError::Timeout) => {
                     if last_block.elapsed() > STALE_BLOCK_DURATION {
@@ -403,6 +502,12 @@ fn main() {
         return;
     }
 
+    let wallet_state = WalletState::new(to_wallet_network(network));
+
+    let node_sock_file = data_dir.clone() + "/node.sock";
+    let wallet_sock_file = data_dir.clone() + "/wallet.sock";
+
+    let wallet_state_for_ipc = wallet_state.clone();
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -411,13 +516,36 @@ fn main() {
         rt.block_on(async move {
             tokio::task::LocalSet::new()
                 .run_until(async move {
-                    let sock_file = data_dir + "/node.sock";
-                    let _ = std::fs::remove_file(&sock_file);
+                    let _ = std::fs::remove_file(&node_sock_file);
+                    let _ = std::fs::remove_file(&wallet_sock_file);
                     info!("Listening for incoming IPC requests");
-                    let unix_socket = UnixListener::bind(sock_file).unwrap();
+                    let node_unix_socket = UnixListener::bind(&node_sock_file).unwrap();
+                    let wallet_unix_socket = UnixListener::bind(&wallet_sock_file).unwrap();
+
+                    tokio::task::spawn_local(async move {
+                        loop {
+                            let stream = wallet_unix_socket.accept().await.unwrap().0;
+                            let state = wallet_state_for_ipc.clone();
+                            let (reader, writer) = stream.into_split();
+                            let buf_reader = futures::io::BufReader::new(reader.compat());
+                            let buf_writer = futures::io::BufWriter::new(writer.compat_write());
+                            let network = capnp_rpc::twoparty::VatNetwork::new(
+                                buf_reader,
+                                buf_writer,
+                                capnp_rpc::rpc_twoparty_capnp::Side::Server,
+                                Default::default(),
+                            );
+                            let client: wallet_ipc::Client =
+                                capnp_rpc::new_client(WalletIpcInterface::new(state));
+                            let rpc_system =
+                                capnp_rpc::RpcSystem::new(Box::new(network), Some(client.client));
+                            tokio::task::spawn_local(rpc_system);
+                        }
+                    });
+
                     loop {
                         let stream = tokio::select! {
-                            unix_bind_res = unix_socket.accept() => {
+                            unix_bind_res = node_unix_socket.accept() => {
                                 unix_bind_res.unwrap().0
                             }
                             _ctrl_c = tokio::signal::ctrl_c() => {
@@ -447,5 +575,14 @@ fn main() {
         })
     });
 
-    run(network, connect, node_state, shutdown_rx, addr_rx, block_rx).unwrap()
+    run(
+        network,
+        connect,
+        node_state,
+        shutdown_rx,
+        addr_rx,
+        block_rx,
+        wallet_state,
+    )
+    .unwrap()
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,6 +1,9 @@
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex};
 
-use crate::server_capnp;
+use secp256k1::{PublicKey, SecretKey};
+use wallet::silentpayments::{build_receiver, Network, SilentPaymentWallet};
+
+use crate::{server_capnp, wallet_capnp};
 
 #[derive(Debug)]
 pub struct IpcInterface {
@@ -33,6 +36,130 @@ impl server_capnp::server::Server for IpcInterface {
         self.tx
             .send(())
             .map_err(|_| capnp::Error::failed("could not shutdown server.".to_string()))?;
+        Ok(())
+    }
+}
+
+/// Shared wallet state accessed by both the block-scanning thread and the IPC server.
+/// Cloning is cheap — all fields are Arc.
+#[derive(Clone)]
+pub struct WalletState {
+    pub wallet: Arc<Mutex<SilentPaymentWallet>>,
+    pub scan_key: Arc<Mutex<Option<SecretKey>>>,
+    pub spend_key: Arc<Mutex<Option<PublicKey>>>,
+    pub network: Network,
+}
+
+impl WalletState {
+    pub fn new(network: Network) -> Self {
+        Self {
+            wallet: Arc::new(Mutex::new(SilentPaymentWallet::new())),
+            scan_key: Arc::new(Mutex::new(None)),
+            spend_key: Arc::new(Mutex::new(None)),
+            network,
+        }
+    }
+}
+
+pub struct WalletIpcInterface {
+    state: WalletState,
+}
+
+impl WalletIpcInterface {
+    pub fn new(state: WalletState) -> Self {
+        Self { state }
+    }
+}
+
+impl wallet_capnp::wallet::Server for WalletIpcInterface {
+    async fn import_keys(
+        self: capnp::capability::Rc<Self>,
+        params: wallet_capnp::wallet::ImportKeysParams,
+        mut results: wallet_capnp::wallet::ImportKeysResults,
+    ) -> Result<(), capnp::Error> {
+        let p = params.get()?;
+        let scan_bytes = p.get_scan_key()?;
+        let spend_bytes = p.get_spend_key()?;
+
+        let scan_key = SecretKey::from_slice(scan_bytes)
+            .map_err(|e| capnp::Error::failed(format!("invalid scan key: {e}")))?;
+        let spend_key = PublicKey::from_slice(spend_bytes)
+            .map_err(|e| capnp::Error::failed(format!("invalid spend key: {e}")))?;
+
+        // Validate that the keys form a valid Receiver before storing.
+        build_receiver(&scan_key, spend_key, self.state.network)
+            .map_err(|e| capnp::Error::failed(format!("invalid key pair: {e}")))?;
+
+        *self.state.scan_key.lock().unwrap() = Some(scan_key);
+        *self.state.spend_key.lock().unwrap() = Some(spend_key);
+
+        results.get().set_ok(true);
+        results.get().set_message("keys imported");
+        Ok(())
+    }
+
+    async fn get_balance(
+        self: capnp::capability::Rc<Self>,
+        _: wallet_capnp::wallet::GetBalanceParams,
+        mut results: wallet_capnp::wallet::GetBalanceResults,
+    ) -> Result<(), capnp::Error> {
+        let wallet = self.state.wallet.lock().unwrap();
+        let balance = wallet.balance();
+        let scan_height = wallet.scan_height;
+        let utxo_count = wallet.utxo_count() as u32;
+        drop(wallet);
+
+        let mut r = results.get();
+        r.set_sats(balance.to_sat());
+        r.set_scan_height(scan_height);
+        r.set_utxo_count(utxo_count);
+        Ok(())
+    }
+
+    async fn get_history(
+        self: capnp::capability::Rc<Self>,
+        _: wallet_capnp::wallet::GetHistoryParams,
+        mut results: wallet_capnp::wallet::GetHistoryResults,
+    ) -> Result<(), capnp::Error> {
+        use wallet::silentpayments::HistoryEntry;
+        let wallet = self.state.wallet.lock().unwrap();
+        let history = wallet.history();
+        drop(wallet);
+
+        let text = history
+            .iter()
+            .map(|e| match e {
+                HistoryEntry::Received {
+                    outpoint,
+                    value,
+                    block_height,
+                } => {
+                    format!(
+                        "recv {}:{} {} sats at {}",
+                        outpoint.txid,
+                        outpoint.vout,
+                        value.to_sat(),
+                        block_height
+                    )
+                }
+                HistoryEntry::Spent {
+                    outpoint,
+                    value,
+                    spent_at,
+                } => {
+                    format!(
+                        "spent {}:{} {} sats at {}",
+                        outpoint.txid,
+                        outpoint.vout,
+                        value.to_sat(),
+                        spent_at
+                    )
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        results.get().set_entries(&text);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod kernel_util;
 pub mod peer;
 
 capnp::generated_code!(pub mod server_capnp);
+capnp::generated_code!(pub mod wallet_capnp);

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -230,6 +230,21 @@ pub fn process_message(
                     (PeerStateMachine::AwaitingInv, vec![])
                 }
             }
+            NetworkMessage::Headers(headers) if !headers.is_empty() => {
+                let block_hashes: Vec<bitcoin::BlockHash> =
+                    headers.iter().map(|h| h.block_hash()).collect();
+                debug!(
+                    "Received {} header(s) as block announcement",
+                    block_hashes.len()
+                );
+                (
+                    PeerStateMachine::AwaitingBlock(AwaitingBlock {
+                        peer_inventory: block_hashes.iter().cloned().collect(),
+                        block_buffer: HashMap::new(),
+                    }),
+                    vec![create_getdata_message(&block_hashes)],
+                )
+            }
             message => {
                 debug!("Ignoring message: {:?}", message);
                 (PeerStateMachine::AwaitingInv, vec![])


### PR DESCRIPTION
Integrate BIP-352 silent payment scanning into kernel-node using the `silentpayments` crate from [SPDK](https://github.com/cygnet3/spdk).
- Add `crates/wallet` as a workspace member with a `silentpayments` submodule that wraps SPDK's cryptographic primitives
- Scan each accepted block for payments using kernel undo data to recover prevout scripts
- Track received UTXOs and balance in an in-memory wallet
- Expose `import_keys`, `balance`, and `history` over a dedicated Cap'n Proto Unix socket (`wallet.sock`)
- Handle headers-first block announcements