### PR TITLE
Revert `bitcoin` to `0.32.x` across the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,18 +69,13 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.2.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes",
 ]
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -110,38 +105,35 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-alpha.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
- "base64",
  "bech32",
  "bitcoin-internals",
- "bitcoin-io 0.2.0",
- "bitcoin-primitives",
+ "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
- "bitcoinconsensus",
- "hex-conservative 0.3.2",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
  "secp256k1",
 ]
 
 [[package]]
 name = "bitcoin-address-book"
-version = "0.1.0"
-source = "git+https://github.com/rustaceanrob/bitcoin-address-book?rev=4417e4c8f5d04245947c758b73fb0dc9e7e0bd15#4417e4c8f5d04245947c758b73fb0dc9e7e0bd15"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060c05780195789a7b89bbfe7f57a1a8cd6ae0bb3daa9b96eeca4fbe0ba8014f"
 dependencies = [
  "bitcoin",
- "bitcoin-p2p-messages",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.4.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
-dependencies = [
- "hex-conservative 0.3.2",
-]
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-io"
@@ -150,55 +142,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.2.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
-dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
-]
-
-[[package]]
 name = "bitcoin-p2p"
 version = "0.1.0"
-source = "git+https://github.com/2140-dev/bitcoin-p2p.git?rev=322c4abb2a947f3f2d85991a0cb450249c68c1ea#322c4abb2a947f3f2d85991a0cb450249c68c1ea"
+source = "git+https://github.com/2140-dev/bitcoin-p2p.git?rev=5dc03375636a10487c7e50659416876c28f58a3b#5dc03375636a10487c7e50659416876c28f58a3b"
 dependencies = [
  "bitcoin",
- "bitcoin-p2p-messages",
-]
-
-[[package]]
-name = "bitcoin-p2p-messages"
-version = "0.1.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
-dependencies = [
- "bitcoin",
- "bitcoin-internals",
- "bitcoin-io 0.2.0",
- "bitcoin-units",
- "bitcoin_hashes 0.16.0",
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoin-primitives"
-version = "0.101.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
-dependencies = [
- "arrayvec",
- "bitcoin-internals",
- "bitcoin-units",
- "bitcoin_hashes 0.16.0",
- "hex-conservative 0.3.2",
 ]
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals",
- "serde",
 ]
 
 [[package]]
@@ -207,26 +164,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
- "bitcoin-io 0.1.4",
- "hex-conservative 0.2.2",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.16.0"
-source = "git+https://github.com/rust-bitcoin/rust-bitcoin?rev=16cc257c3695dea0e7301a5fa9cab44b8ed60598#16cc257c3695dea0e7301a5fa9cab44b8ed60598"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoinconsensus"
-version = "0.106.0+26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12cba9cce5043cdda968e07b9df6d05ec6b0b38aa27a9a40bb575cf3e521ae9"
-dependencies = [
- "cc",
+ "bitcoin-io",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -596,13 +535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex-conservative"
-version = "0.3.2"
+name = "hex_lit"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
-dependencies = [
- "arrayvec",
-]
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "humantime"
@@ -879,11 +815,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ rust-version = "1.84.0"
 [dependencies]
 # bitcoinkernel = { path = "../rust-bitcoinkernel", version = "0.0.15" }
 bitcoinkernel = "0.2"
-addrman = { package = "bitcoin-address-book", git = "https://github.com/rustaceanrob/bitcoin-address-book", rev = "4417e4c8f5d04245947c758b73fb0dc9e7e0bd15" }
-bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", default-features = false, rev = "16cc257c3695dea0e7301a5fa9cab44b8ed60598" }
-p2p = { package = "bitcoin-p2p", git =  "https://github.com/2140-dev/bitcoin-p2p.git", rev = "322c4abb2a947f3f2d85991a0cb450249c68c1ea" }
+addrman = { package = "bitcoin-address-book", version = "0.1.1" }
+bitcoin = "0.32.8"
+p2p = { package = "bitcoin-p2p", git =  "https://github.com/2140-dev/bitcoin-p2p.git", rev = "5dc03375636a10487c7e50659416876c28f58a3b" }
 ## Log and configuration
 configure_me = "0.4.0"
 clap = { version = "4", features = ["derive"] }

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -10,13 +10,18 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bitcoin::{BlockHash, Network, TestnetVersion};
+use bitcoin::p2p::{
+    address::{AddrV2, AddrV2Message},
+    ServiceFlags,
+};
+use bitcoin::{hashes::Hash, BlockHash, Network};
 use bitcoinkernel::{
     core::BlockHashExt, prelude::BlockValidationStateExt, ChainType, ChainstateManagerBuilder,
     Context, ContextBuilder, Log, Logger, SynchronizationState, ValidationMode,
 };
 use kernel_node::{
     daemonize::Daemonize,
+    kernel_util::NetworkExt,
     peer::{BitcoinPeer, NodeState, TipState},
 };
 use kernel_node::{
@@ -25,10 +30,7 @@ use kernel_node::{
     server_capnp::server,
 };
 use log::{debug, error, info, warn};
-use p2p::{
-    dns::{BITCOIN_SEEDS, SIGNET_SEEDS, TESTNET3_SEEDS, TESTNET4_SEEDS},
-    p2p_message_types::{address::AddrV2, message::AddrV2Payload, NetworkExt, ServiceFlags},
-};
+use p2p::dns::{BITCOIN_SEEDS, SIGNET_SEEDS, TESTNET3_SEEDS, TESTNET4_SEEDS};
 use tokio::net::UnixListener;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -146,14 +148,9 @@ fn resolve_seeds(network: Network) -> Vec<IpAddr> {
     let seeds: Vec<String> = match network {
         Network::Bitcoin => BITCOIN_SEEDS.into_iter().map(format_hostname).collect(),
         Network::Signet => SIGNET_SEEDS.into_iter().map(format_hostname).collect(),
-        Network::Testnet(TestnetVersion::V3) => {
-            TESTNET3_SEEDS.into_iter().map(format_hostname).collect()
-        }
-        Network::Testnet(TestnetVersion::V4) => {
-            TESTNET4_SEEDS.into_iter().map(format_hostname).collect()
-        }
+        Network::Testnet => TESTNET3_SEEDS.into_iter().map(format_hostname).collect(),
+        Network::Testnet4 => TESTNET4_SEEDS.into_iter().map(format_hostname).collect(),
         Network::Regtest => Vec::new(),
-        _ => panic!("unknown network."),
     };
     let mut results = Vec::new();
     for host in seeds {
@@ -173,7 +170,7 @@ fn run(
     connect: Option<SocketAddr>,
     mut node_state: NodeState,
     shutdown_rx: mpsc::Receiver<()>,
-    addr_rx: mpsc::Receiver<AddrV2Payload>,
+    addr_rx: mpsc::Receiver<Vec<AddrV2Message>>,
     block_rx: mpsc::Receiver<bitcoinkernel::Block>,
 ) -> std::io::Result<()> {
     let mut table = addrman::Table::<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>::new();
@@ -284,7 +281,7 @@ fn run(
             match addr_rx.recv() {
                 Ok(payload) => {
                     let mut addr_lock = addrman.lock().unwrap();
-                    for address in payload.0 {
+                    for address in payload {
                         let record = addrman::Record::new(
                             address.addr,
                             address.port,

--- a/src/kernel_util.rs
+++ b/src/kernel_util.rs
@@ -1,4 +1,4 @@
-use bitcoin::{block::Checked, consensus::encode, Network, TestnetVersion};
+use bitcoin::{consensus::encode, hashes::Hash, Network};
 use bitcoinkernel::{core::BlockHashExt, BlockTreeEntry, ChainType};
 use std::{fs, path::PathBuf};
 
@@ -11,10 +11,9 @@ impl ChainExt for Network {
         match self {
             Network::Bitcoin => ChainType::Mainnet,
             Network::Signet => ChainType::Signet,
-            Network::Testnet(TestnetVersion::V3) => ChainType::Testnet,
-            Network::Testnet(TestnetVersion::V4) => ChainType::Testnet4,
+            Network::Testnet => ChainType::Testnet,
+            Network::Testnet4 => ChainType::Testnet4,
             Network::Regtest => ChainType::Regtest,
-            _ => unimplemented!("unsupported network"),
         }
     }
 }
@@ -46,13 +45,31 @@ impl<S: AsRef<str>> DirnameExt for S {
     }
 }
 
-pub fn bitcoin_block_to_kernel_block(block: &bitcoin::Block<Checked>) -> bitcoinkernel::Block {
+pub trait NetworkExt {
+    // The P2P port for a given [`Network`].
+    fn default_p2p_port(self) -> u16;
+}
+
+impl NetworkExt for Network {
+    // The P2P port for a given [`Network`].
+    fn default_p2p_port(self) -> u16 {
+        match &self {
+            Self::Bitcoin => 8333,
+            Self::Signet => 38333,
+            Self::Testnet => 18333,
+            Self::Testnet4 => 48333,
+            Self::Regtest => 18444,
+        }
+    }
+}
+
+pub fn bitcoin_block_to_kernel_block(block: &bitcoin::Block) -> bitcoinkernel::Block {
     let ser_block = encode::serialize(block);
     bitcoinkernel::Block::try_from(ser_block.as_slice()).unwrap()
 }
 
 pub fn bitcoin_header_to_kernel_header(
-    header: &bitcoin::BlockHeader,
+    header: &bitcoin::block::Header,
 ) -> bitcoinkernel::BlockHeader {
     let ser_header = encode::serialize(header);
     bitcoinkernel::BlockHeader::new(ser_header.as_slice()).unwrap()

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -5,6 +5,15 @@ use std::{
     sync::{mpsc, Arc, Mutex},
 };
 
+use bitcoin::{
+    hashes::Hash,
+    p2p::{
+        address::AddrV2Message,
+        message::NetworkMessage,
+        message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory},
+        Address, ServiceFlags,
+    },
+};
 use bitcoin::{BlockHash, Network};
 use bitcoinkernel::{
     core::BlockHashExt, prelude::BlockValidationStateExt, BlockTreeEntry, ChainstateManager,
@@ -12,19 +21,13 @@ use bitcoinkernel::{
 };
 use log::{debug, info, warn};
 use p2p::{
-    handshake::ConnectionConfig,
+    handshake::{ConnectionConfig, ProtocolVersion},
     net::{ConnectionExt, ConnectionReader, ConnectionWriter, TimeoutParams},
-    p2p_message_types::{
-        message::{AddrV2Payload, InventoryPayload, NetworkMessage},
-        message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory},
-        message_network::UserAgent,
-        Address, ProtocolVersion, ServiceFlags,
-    },
 };
 
 use crate::kernel_util::{bitcoin_block_to_kernel_block, bitcoin_header_to_kernel_header};
 
-const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::INVALID_CB_NO_BAN_VERSION;
+const PROTOCOL_VERSION: ProtocolVersion = 70015;
 const MAX_LOCATOR_HASHES: usize = 101;
 
 #[derive(Clone)]
@@ -35,13 +38,13 @@ pub struct TipState {
 impl Default for TipState {
     fn default() -> Self {
         Self {
-            block_hash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+            block_hash: BlockHash::all_zeros(),
         }
     }
 }
 
 pub struct NodeState {
-    pub addr_tx: mpsc::Sender<AddrV2Payload>,
+    pub addr_tx: mpsc::Sender<Vec<AddrV2Message>>,
     pub block_tx: mpsc::SyncSender<bitcoinkernel::Block>,
     pub tip_state: Arc<Mutex<TipState>>,
     pub context: Arc<Context>,
@@ -124,7 +127,7 @@ fn create_getheaders_message(locator_hashes: Vec<bitcoin::BlockHash>) -> Network
     NetworkMessage::GetHeaders(GetHeadersMessage {
         version: PROTOCOL_VERSION,
         locator_hashes,
-        stop_hash: bitcoin::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+        stop_hash: bitcoin::BlockHash::all_zeros(),
     })
 }
 
@@ -132,7 +135,7 @@ fn create_getblocks_message(locator_hashes: Vec<bitcoin::BlockHash>) -> NetworkM
     NetworkMessage::GetBlocks(GetBlocksMessage {
         version: PROTOCOL_VERSION,
         locator_hashes,
-        stop_hash: bitcoin::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+        stop_hash: bitcoin::BlockHash::all_zeros(),
     })
 }
 
@@ -142,7 +145,7 @@ fn create_getdata_message(block_hashes: &[bitcoin::BlockHash]) -> NetworkMessage
         .map(|hash| Inventory::WitnessBlock(*hash))
         .collect();
 
-    NetworkMessage::GetData(InventoryPayload(inventory))
+    NetworkMessage::GetData(inventory)
 }
 
 pub fn process_message(
@@ -157,7 +160,7 @@ pub fn process_message(
     }
 
     if let NetworkMessage::AddrV2(payload) = event {
-        info!("Received {} net addresses", payload.0.len());
+        info!("Received {} net addresses", payload.len());
         // If the address manager has a full queue these net addresses should be dropped.
         let _ = node_state.addr_tx.send(payload);
         return (state_machine, vec![]);
@@ -166,7 +169,7 @@ pub fn process_message(
     match state_machine {
         PeerStateMachine::AwaitingHeaders => match event {
             NetworkMessage::Headers(headers) => {
-                for header in &headers.0 {
+                for header in &headers {
                     let result = node_state
                         .chainman
                         .process_block_header(&bitcoin_header_to_kernel_header(header));
@@ -174,7 +177,7 @@ pub fn process_message(
                         ProcessBlockHeaderResult::Success(state)
                             if state.mode() == ValidationMode::Valid =>
                         {
-                            debug!("Processed header: {}", header.time.to_u32());
+                            debug!("Processed header: {}", header.time);
                             continue;
                         }
                         _ => {
@@ -184,7 +187,7 @@ pub fn process_message(
                     }
                 }
 
-                if headers.0.len() != 2000 {
+                if headers.len() != 2000 {
                     let locators = build_block_locators(node_state.chainman.active_chain().tip());
                     return (
                         PeerStateMachine::AwaitingInv,
@@ -205,9 +208,8 @@ pub fn process_message(
         },
         PeerStateMachine::AwaitingInv => match event {
             NetworkMessage::Inv(inventory) => {
-                debug!("Received inventory with {} items", inventory.0.len());
+                debug!("Received inventory with {} items", inventory.len());
                 let block_hashes: Vec<bitcoin::BlockHash> = inventory
-                    .0
                     .iter()
                     .filter_map(|inv| match inv {
                         Inventory::Block(hash) => Some(*hash),
@@ -235,8 +237,7 @@ pub fn process_message(
         },
         PeerStateMachine::AwaitingBlock(mut block_state) => match event {
             NetworkMessage::Block(block) => {
-                let block = block.assume_checked(None);
-                let prev_blockhash = block.header().prev_blockhash;
+                let prev_blockhash = block.header.prev_blockhash;
                 block_state.peer_inventory.remove(&block.block_hash());
                 block_state
                     .block_buffer
@@ -300,7 +301,7 @@ impl BitcoinPeer {
             .request_addr()
             .set_service_requirement(ServiceFlags::NETWORK)
             .offer_services(ServiceFlags::WITNESS)
-            .user_agent(UserAgent::from_nonstandard("kernel-node"));
+            .user_agent("/kernel-node:0.1.0/".into());
         let (writer, reader, _) = conf.open_connection(socket_addr, TimeoutParams::new())?;
 
         let addr = Address::new(&socket_addr, ServiceFlags::WITNESS);


### PR DESCRIPTION
I was overly optimisitic on the timeline for `0.33.0` and the release of `primitives` for `rust-bitcoin`, which made for a very unfortunate version mismatch with the rest of the Rust ecosystem. To keep the ball rolling on new features and experimentation, this reverts the `bitcoin` version to the widely adopted `0.32.x`.