### PR TITLE
Bump MSRV to `1.85.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kernel-node"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 [dependencies]
 # bitcoinkernel = { path = "../rust-bitcoinkernel", version = "0.0.15" }


### PR DESCRIPTION
Ubuntu `26.04` supports Rust `1.91` and above. `bdk_wallet` has an MSRV of `1.85.0`. Given that we will likely want to add a wallet here, an MSRV bump seems appropriate.