### PR TITLE
silent payments: integrate SPDK scanning and wallet IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -74,14 +74,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.1",
 ]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bindgen"
@@ -110,12 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.1",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
 ]
@@ -151,11 +163,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
 dependencies = [
  "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446819536d8121575eeb7e89efdbadb3f055e87e4bb66c6679a6d5cc2f4b64fd"
+dependencies = [
+ "hex-conservative 0.1.2",
 ]
 
 [[package]]
@@ -165,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -179,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bytes"
@@ -191,9 +212,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capnp"
-version = "0.25.2"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c982cc37b8f646c753f3b0a24d4d40ca2eac8a9c2b9ea6fff524be67ddc184cb"
+checksum = "63da65e5e9ffc3b8f993d4ad222a548152549351a643f6b850a7773cb6ff2809"
 dependencies = [
  "embedded-io",
 ]
@@ -211,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "capnp-rpc"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ccca6d26009f4d6c12b741994f33b421da613b5dcf461508e236b53ef862f1"
+checksum = "e3c74c337e87f75f3174ffb3513738ab0acc631c04f64cc33b867c60f84771da"
 dependencies = [
  "capnp",
  "capnp-futures",
@@ -222,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "capnpc"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6cdfa6b0df161a71201367910265b97180541ecdb48bd08e05ef8694c295d1f"
+checksum = "fca02be865c8c5a78bfc24b9819006ab6b59bef238467203928e26459557af93"
 dependencies = [
  "capnp",
 ]
@@ -241,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -277,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -287,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -299,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -311,15 +332,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "configure_me"
@@ -509,9 +530,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -524,6 +545,18 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -548,9 +581,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -602,6 +635,7 @@ dependencies = [
  "log",
  "tokio",
  "tokio-util",
+ "wallet",
 ]
 
 [[package]]
@@ -616,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -659,9 +693,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -744,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -809,9 +843,9 @@ checksum = "e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "secp256k1"
@@ -819,7 +853,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.1",
  "rand",
  "secp256k1-sys",
 ]
@@ -889,6 +923,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "silentpayments"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131d42e3050dd88c79e4849b27eaf0cda0625f4e910d97bf05044a1300459f85"
+dependencies = [
+ "bech32 0.9.1",
+ "bimap",
+ "bitcoin_hashes 0.13.1",
+ "hex",
+ "secp256k1",
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "libc",
  "mio",
@@ -947,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1028,9 +1076,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "utf8parse"
@@ -1043,6 +1091,16 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wallet"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "bitcoinkernel",
+ "log",
+ "silentpayments",
+]
 
 [[package]]
 name = "wasi"
@@ -1085,18 +1143,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "crates/wallet"]
+resolver = "2"
+
 [package]
 name = "kernel-node"
 version = "0.1.0"
@@ -15,6 +19,7 @@ configure_me = "0.4.0"
 clap = { version = "4", features = ["derive"] }
 log = "0.4"
 env_logger = "0.10"
+wallet = { path = "crates/wallet" }
 ## IPC required dependencies
 capnp = "0.25"
 capnp-rpc = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.85.0"
 # bitcoinkernel = { path = "../rust-bitcoinkernel", version = "0.0.15" }
 bitcoinkernel = "0.2"
 addrman = { package = "bitcoin-address-book", version = "0.1.1" }
-bitcoin = "0.32.8"
+bitcoin = { version = "0.32.8", features = ["rand-std"] }
 p2p = { package = "bitcoin-p2p", git =  "https://github.com/2140-dev/bitcoin-p2p.git", rev = "5dc03375636a10487c7e50659416876c28f58a3b" }
 ## Log and configuration
 configure_me = "0.4.0"

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), configure_me_codegen::Error> {
     CompilerCommand::new()
         .src_prefix("capnp")
         .file("capnp/server.capnp")
+        .file("capnp/wallet.capnp")
         .run()
         .unwrap();
     configure_me_codegen::build_script_auto()

--- a/capnp/server.capnp
+++ b/capnp/server.capnp
@@ -1,6 +1,9 @@
 @0xc2e20cc9503cf68f;
 
+using Wallet = import "wallet.capnp";
+
 interface Server {
     echo @0 (msg :Text) -> (reply :Text);
     shutdown @1 () -> ();
+    makeWallet @2 () -> (wallet :Wallet.Wallet);
 }

--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -1,0 +1,8 @@
+@0xb5d3a2f1e8c47690;
+
+interface Wallet {
+    importKeys @0 (scanKey :Data, spendKey :Data) -> (ok :Bool, message :Text);
+    getBalance  @1 () -> (sats :UInt64, scanHeight :UInt32, utxoCount :UInt32);
+    getHistory  @2 () -> (entries :Text);
+    receive     @3 () -> (address :Text);
+}

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wallet"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+silentpayments = { version = "0.5", features = ["receiving", "encode"] }
+bitcoin = "0.32.8"
+bitcoinkernel = "0.2"
+log = "0.4"

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod silentpayments;

--- a/crates/wallet/src/silentpayments/mod.rs
+++ b/crates/wallet/src/silentpayments/mod.rs
@@ -1,0 +1,20 @@
+mod scanning;
+mod wallet;
+
+pub use ::silentpayments::receiving::{Label, Receiver};
+pub use ::silentpayments::{Network, SilentPaymentAddress};
+pub use scanning::{scan_transaction, InputData};
+pub use wallet::{Coin, HistoryEntry, SilentPaymentKeys, SpentBy, Wallet};
+
+use bitcoin::secp256k1::{self, PublicKey, SecretKey};
+
+pub fn build_receiver(
+    b_scan: &SecretKey,
+    b_spend_pub: PublicKey,
+    network: Network,
+) -> Result<Receiver, ::silentpayments::Error> {
+    let secp = secp256k1::Secp256k1::signing_only();
+    let scan_pubkey = PublicKey::from_secret_key(&secp, b_scan);
+    let change_label = Label::new(*b_scan, 0);
+    Receiver::new(0, scan_pubkey, b_spend_pub, change_label, network)
+}

--- a/crates/wallet/src/silentpayments/scanning.rs
+++ b/crates/wallet/src/silentpayments/scanning.rs
@@ -1,0 +1,153 @@
+use ::silentpayments::{
+    receiving::{Label, Receiver},
+    utils::receiving::{calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input},
+};
+use bitcoin::consensus::encode;
+use bitcoin::secp256k1::{self, Scalar, SecretKey, XOnlyPublicKey};
+use bitcoin::{OutPoint, Script, Transaction};
+use bitcoinkernel::prelude::{
+    BlockSpentOutputsExt, CoinExt, ScriptPubkeyExt, TransactionExt, TransactionSpentOutputsExt,
+    TxOutExt,
+};
+
+use crate::silentpayments::wallet::Coin;
+
+pub struct InputData {
+    pub script_sig: Vec<u8>,
+    pub witness: Vec<Vec<u8>>,
+    pub prevout_script: Vec<u8>,
+    pub txid: String,
+    pub vout: u32,
+}
+
+pub fn scan_transaction(
+    receiver: &Receiver,
+    b_scan: &SecretKey,
+    inputs: &[InputData],
+    tx: &Transaction,
+) -> Vec<(usize, Scalar, Option<Label>)> {
+    let mut input_pub_keys = Vec::new();
+    let mut outpoints = Vec::new();
+    for input in inputs {
+        if let Ok(Some(pk)) =
+            get_pubkey_from_input(&input.script_sig, &input.witness, &input.prevout_script)
+        {
+            input_pub_keys.push(pk);
+            outpoints.push((input.txid.clone(), input.vout));
+        }
+    }
+
+    if input_pub_keys.is_empty() {
+        return vec![];
+    }
+
+    // Silent payments always produce taproot outputs — skip transactions without any.
+    let taproot_outputs: Vec<(usize, XOnlyPublicKey)> = tx
+        .output
+        .iter()
+        .enumerate()
+        .filter_map(|(i, out)| {
+            if out.script_pubkey.is_p2tr() {
+                XOnlyPublicKey::from_slice(&out.script_pubkey.as_bytes()[2..])
+                    .ok()
+                    .map(|pk| (i, pk))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if taproot_outputs.is_empty() {
+        return vec![];
+    }
+
+    let pubkey_refs: Vec<&secp256k1::PublicKey> = input_pub_keys.iter().collect();
+    let tweak_data = match calculate_tweak_data(&pubkey_refs, &outpoints) {
+        Ok(td) => td,
+        Err(_) => return vec![],
+    };
+    let shared_secret = calculate_ecdh_shared_secret(&tweak_data, b_scan);
+
+    let xonly_outputs: Vec<XOnlyPublicKey> = taproot_outputs.iter().map(|(_, pk)| *pk).collect();
+    let found = match receiver.scan_transaction(&shared_secret, xonly_outputs) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+
+    let mut result = Vec::new();
+    for (label, pubkey_map) in found.iter() {
+        for (pk, tweak) in pubkey_map {
+            if let Some((idx, _)) = taproot_outputs.iter().find(|(_, o)| o == pk) {
+                result.push((*idx, *tweak, label.clone()));
+            }
+        }
+    }
+    result
+}
+
+pub(crate) fn scan_block_inner(
+    receiver: &Receiver,
+    b_scan: &SecretKey,
+    kernel_block: &bitcoinkernel::Block,
+    spent_outputs: &bitcoinkernel::BlockSpentOutputs,
+    block_height: u32,
+) -> Vec<(OutPoint, Coin)> {
+    let mut found: Vec<(OutPoint, Coin)> = Vec::new();
+
+    // Skip coinbase; spent_outputs[i] maps to kernel_block.transactions().skip(1)[i].
+    for (kernel_tx, tx_spent) in kernel_block
+        .transactions()
+        .skip(1)
+        .zip(spent_outputs.iter())
+    {
+        let has_p2tr = kernel_tx.outputs().any(|out| {
+            let bytes = out.script_pubkey().to_bytes();
+            Script::from_bytes(&bytes).is_p2tr()
+        });
+        if !has_p2tr {
+            continue;
+        }
+
+        let tx_bytes = kernel_tx
+            .consensus_encode()
+            .expect("kernel tx serialization");
+        let btc_tx: Transaction =
+            encode::deserialize(&tx_bytes).expect("kernel tx deserialization");
+
+        let mut inputs = Vec::with_capacity(btc_tx.input.len());
+        for (input_idx, btc_input) in btc_tx.input.iter().enumerate() {
+            let coin = tx_spent
+                .coin(input_idx)
+                .expect("input/spent-output count mismatch");
+            inputs.push(InputData {
+                script_sig: btc_input.script_sig.as_bytes().to_vec(),
+                witness: btc_input.witness.iter().map(|item| item.to_vec()).collect(),
+                prevout_script: coin.output().script_pubkey().to_bytes(),
+                txid: btc_input.previous_output.txid.to_string(),
+                vout: btc_input.previous_output.vout,
+            });
+        }
+
+        let txid = btc_tx.compute_txid();
+        for (output_index, tweak, label) in scan_transaction(receiver, b_scan, &inputs, &btc_tx) {
+            if let Some(out) = btc_tx.output.get(output_index) {
+                let outpoint = OutPoint {
+                    txid,
+                    vout: output_index as u32,
+                };
+                found.push((
+                    outpoint,
+                    Coin {
+                        value: out.value,
+                        script_pubkey: out.script_pubkey.clone(),
+                        tweak,
+                        label,
+                        block_height,
+                        spent_by: None,
+                    },
+                ));
+            }
+        }
+    }
+    found
+}

--- a/crates/wallet/src/silentpayments/wallet.rs
+++ b/crates/wallet/src/silentpayments/wallet.rs
@@ -1,0 +1,208 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
+
+use bitcoin::secp256k1::{PublicKey, Scalar, SecretKey};
+use bitcoin::{hashes::Hash, Amount, OutPoint, ScriptBuf, Txid};
+use bitcoinkernel::prelude::{TransactionExt, TxInExt, TxOutPointExt, TxidExt};
+
+use crate::silentpayments::scanning::scan_block_inner;
+use crate::silentpayments::{Label, Network, Receiver};
+
+#[derive(Debug)]
+pub struct SilentPaymentKeys {
+    pub receiver: Receiver,
+    pub scan_key: SecretKey,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpentBy {
+    pub txid: Txid,
+    pub block_height: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct Coin {
+    pub value: Amount,
+    pub script_pubkey: ScriptBuf,
+    pub tweak: Scalar,
+    pub label: Option<Label>,
+    pub block_height: u32,
+    pub spent_by: Option<SpentBy>,
+}
+
+pub enum HistoryEntry {
+    Received {
+        outpoint: OutPoint,
+        value: Amount,
+        block_height: u32,
+    },
+    Spent {
+        outpoint: OutPoint,
+        value: Amount,
+        spent_at: u32,
+    },
+}
+
+impl fmt::Display for HistoryEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HistoryEntry::Received {
+                outpoint,
+                value,
+                block_height,
+            } => write!(
+                f,
+                "recv {}:{} {} sats at {}",
+                outpoint.txid,
+                outpoint.vout,
+                value.to_sat(),
+                block_height
+            ),
+            HistoryEntry::Spent {
+                outpoint,
+                value,
+                spent_at,
+            } => write!(
+                f,
+                "spent {}:{} {} sats at {}",
+                outpoint.txid,
+                outpoint.vout,
+                value.to_sat(),
+                spent_at
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Wallet {
+    pub scan_height: u32,
+    pub keys: Option<SilentPaymentKeys>,
+    pub spend_key: Option<PublicKey>,
+    pub network: Network,
+    utxos: HashMap<OutPoint, Coin>,
+}
+
+impl Wallet {
+    pub fn new(network: Network) -> Self {
+        Self {
+            scan_height: 0,
+            keys: None,
+            spend_key: None,
+            network,
+            utxos: HashMap::new(),
+        }
+    }
+
+    pub fn scan_block(
+        &mut self,
+        kernel_block: &bitcoinkernel::Block,
+        spent_outputs: &bitcoinkernel::BlockSpentOutputs,
+        block_height: u32,
+    ) -> usize {
+        let Some(keys) = self.keys.as_ref() else {
+            return 0;
+        };
+        let receiver = keys.receiver.clone();
+        let scan_key = keys.scan_key;
+
+        let found = scan_block_inner(
+            &receiver,
+            &scan_key,
+            kernel_block,
+            spent_outputs,
+            block_height,
+        );
+        let count = found.len();
+
+        for (outpoint, coin) in found {
+            self.utxos.insert(outpoint, coin);
+        }
+
+        for kernel_tx in kernel_block.transactions() {
+            let spending_txid = Txid::from_byte_array(kernel_tx.txid().to_bytes());
+            for input in kernel_tx.inputs() {
+                let kop = input.outpoint();
+                let prev = OutPoint {
+                    txid: Txid::from_byte_array(kop.txid().to_bytes()),
+                    vout: kop.index(),
+                };
+                if let Some(utxo) = self.utxos.get_mut(&prev) {
+                    utxo.spent_by = Some(SpentBy {
+                        txid: spending_txid,
+                        block_height,
+                    });
+                }
+            }
+        }
+
+        self.scan_height = block_height;
+        count
+    }
+
+    pub fn process_disconnect(&mut self, kernel_block: &bitcoinkernel::Block) {
+        let block_txids: HashSet<Txid> = kernel_block
+            .transactions()
+            .map(|tx| Txid::from_byte_array(tx.txid().to_bytes()))
+            .collect();
+
+        self.utxos
+            .retain(|outpoint, _| !block_txids.contains(&outpoint.txid));
+
+        for utxo in self.utxos.values_mut() {
+            if let Some(ref s) = utxo.spent_by {
+                if block_txids.contains(&s.txid) {
+                    utxo.spent_by = None;
+                }
+            }
+        }
+    }
+
+    pub fn utxo_count(&self) -> usize {
+        self.utxos.values().filter(|u| u.spent_by.is_none()).count()
+    }
+
+    pub fn receive_address(&self) -> Option<String> {
+        self.keys
+            .as_ref()
+            .map(|k| k.receiver.get_receiving_address().to_string())
+    }
+
+    pub fn balance(&self) -> Amount {
+        self.utxos
+            .values()
+            .filter(|u| u.spent_by.is_none())
+            .map(|u| u.value)
+            .fold(Amount::ZERO, |acc, v| acc + v)
+    }
+
+    pub fn history(&self) -> Vec<HistoryEntry> {
+        let mut entries: Vec<HistoryEntry> = self
+            .utxos
+            .iter()
+            .flat_map(|(outpoint, utxo)| {
+                let mut v = vec![HistoryEntry::Received {
+                    outpoint: *outpoint,
+                    value: utxo.value,
+                    block_height: utxo.block_height,
+                }];
+                if let Some(ref s) = utxo.spent_by {
+                    v.push(HistoryEntry::Spent {
+                        outpoint: *outpoint,
+                        value: utxo.value,
+                        spent_at: s.block_height,
+                    });
+                }
+                v
+            })
+            .collect();
+
+        entries.sort_by_key(|e| match e {
+            HistoryEntry::Received { block_height, .. } => *block_height,
+            HistoryEntry::Spent { spent_at, .. } => *spent_at,
+        });
+        entries
+    }
+}

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,3 +1,5 @@
+use bitcoin::hex::FromHex;
+use bitcoin::secp256k1::{rand::rngs::OsRng, Secp256k1, SecretKey, XOnlyPublicKey};
 use clap::Parser;
 use kernel_node::kernel_util::DirnameExt;
 use kernel_node::server_capnp::server;
@@ -28,6 +30,9 @@ enum Commands {
     Echo(Echo),
     /// Terminate the server.
     Stop,
+    /// Wallet commands.
+    #[command(subcommand)]
+    Wallet(WalletCmd),
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -36,31 +41,80 @@ struct Echo {
     message: String,
 }
 
+#[derive(Debug, Clone, clap::Subcommand)]
+enum WalletCmd {
+    /// Generate fresh scan and spend keys for receiving silent payments.
+    ///
+    /// Prints the scan private key, spend private key, and spend x-only public
+    /// key as hex on stdout. WARNING: scan_key and spend_priv must be kept secret
+    /// — anyone with them can spend received funds.
+    GenerateKeys,
+    /// Import BIP-352 silent payment keys to enable scanning for incoming payments.
+    ///
+    /// Both keys are hex-encoded. The scan key derives the ECDH shared secret with
+    /// each transaction; the spend pubkey identifies the receiver.
+    ImportKeys {
+        /// 32-byte scan private key as hex.
+        scan_key: String,
+        /// 32-byte x-only spend public key as hex.
+        spend_key: String,
+    },
+    /// Show wallet balance.
+    Balance,
+    /// Show wallet transaction history.
+    History,
+    /// Show the silent payment address the wallet is scanning for.
+    Receive,
+}
+
+fn generate_keys() -> (SecretKey, SecretKey, XOnlyPublicKey) {
+    let secp = Secp256k1::new();
+    let scan_priv = SecretKey::new(&mut OsRng);
+    let spend_priv = SecretKey::new(&mut OsRng);
+    let (spend_xonly, _) = spend_priv.public_key(&secp).x_only_public_key();
+    (scan_priv, spend_priv, spend_xonly)
+}
+
+async fn connect_server(datadir_path: &str) -> server::Client {
+    let sock_file = datadir_path.to_owned() + "/node.sock";
+    let stream = UnixStream::connect(&sock_file)
+        .await
+        .expect("Could not connect to node.sock. Is `node` running?");
+    let (reader, writer) = stream.into_split();
+    let buf_reader = futures::io::BufReader::new(reader.compat());
+    let buf_writer = futures::io::BufWriter::new(writer.compat_write());
+    let network = capnp_rpc::twoparty::VatNetwork::new(
+        buf_reader,
+        buf_writer,
+        capnp_rpc::rpc_twoparty_capnp::Side::Client,
+        Default::default(),
+    );
+    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
+    let client: server::Client = rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+    tokio::task::spawn_local(rpc_system);
+    client
+}
+
 fn main() {
     let cli = Args::parse();
+
+    if let Commands::Wallet(WalletCmd::GenerateKeys) = &cli.commands {
+        let (scan_priv, spend_priv, spend_pub) = generate_keys();
+        eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
+        println!("scan_key={}", scan_priv.display_secret());
+        println!("spend_priv={}", spend_priv.display_secret());
+        println!("spend_pub={}", spend_pub);
+        return;
+    }
+
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .unwrap();
     let datadir_path = cli.opts.datadir.unwrap_or(DEFAULT_DATA_DIR.data_dir());
-    let sock_file = datadir_path + "/node.sock";
+
     rt.block_on(tokio::task::LocalSet::new().run_until(async move {
-        let stream = UnixStream::connect(sock_file)
-            .await
-            .expect("Could not connect to unix socket. Is `node` running?");
-        let (reader, writer) = stream.into_split();
-        let buf_reader = futures::io::BufReader::new(reader.compat());
-        let buf_writer = futures::io::BufWriter::new(writer.compat_write());
-        let network = capnp_rpc::twoparty::VatNetwork::new(
-            buf_reader,
-            buf_writer,
-            capnp_rpc::rpc_twoparty_capnp::Side::Client,
-            Default::default(),
-        );
-        let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
-        let client: server::Client =
-            rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
-        tokio::task::spawn_local(rpc_system);
+        let client = connect_server(&datadir_path).await;
         match cli.commands {
             Commands::Echo(echo) => {
                 let mut echo_req = client.echo_request();
@@ -80,6 +134,59 @@ fn main() {
                 let shutdown_req = client.shutdown_request();
                 shutdown_req.send().promise.await.unwrap();
                 println!("Kernel node stopping...");
+            }
+            Commands::Wallet(cmd) => {
+                let wallet_response = client.make_wallet_request().send().promise.await.unwrap();
+                let client = wallet_response.get().unwrap().get_wallet().unwrap();
+                match cmd {
+                    WalletCmd::GenerateKeys => unreachable!("handled before runtime"),
+                    WalletCmd::ImportKeys {
+                        scan_key,
+                        spend_key,
+                    } => {
+                        let scan_bytes =
+                            Vec::<u8>::from_hex(&scan_key).expect("scan_key must be valid hex");
+                        let spend_bytes =
+                            Vec::<u8>::from_hex(&spend_key).expect("spend_key must be valid hex");
+
+                        let mut req = client.import_keys_request();
+                        req.get().set_scan_key(&scan_bytes);
+                        req.get().set_spend_key(&spend_bytes);
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let msg = r.get_message().unwrap().to_string().unwrap();
+                        println!("{}", msg);
+                    }
+                    WalletCmd::Balance => {
+                        let req = client.get_balance_request();
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        println!(
+                            "Balance: {} sats | scan height: {} | UTXOs: {}",
+                            r.get_sats(),
+                            r.get_scan_height(),
+                            r.get_utxo_count(),
+                        );
+                    }
+                    WalletCmd::History => {
+                        let req = client.get_history_request();
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let entries = r.get_entries().unwrap().to_string().unwrap();
+                        if entries.is_empty() {
+                            println!("No history yet.");
+                        } else {
+                            println!("{}", entries);
+                        }
+                    }
+                    WalletCmd::Receive => {
+                        let req = client.receive_request();
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let address = r.get_address().unwrap().to_string().unwrap();
+                        println!("{}", address);
+                    }
+                }
             }
         }
     }))

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -16,23 +16,22 @@ use bitcoin::p2p::{
 };
 use bitcoin::{hashes::Hash, BlockHash, Network};
 use bitcoinkernel::{
-    core::BlockHashExt, prelude::BlockValidationStateExt, ChainType, ChainstateManagerBuilder,
-    Context, ContextBuilder, Log, Logger, SynchronizationState, ValidationMode,
+    core::BlockHashExt, prelude::BlockValidationStateExt, ChainType, ChainstateManager,
+    ChainstateManagerBuilder, Context, ContextBuilder, Log, Logger, SynchronizationState,
+    ValidationMode,
 };
 use kernel_node::{
     daemonize::Daemonize,
-    kernel_util::NetworkExt,
-    peer::{BitcoinPeer, NodeState, TipState},
-};
-use kernel_node::{
     ipc::IpcInterface,
-    kernel_util::{ChainExt, DirnameExt},
+    kernel_util::{ChainExt, DirnameExt, NetworkExt},
+    peer::{BitcoinPeer, NodeState, TipState},
     server_capnp::server,
 };
 use log::{debug, error, info, warn};
 use p2p::dns::{BITCOIN_SEEDS, SIGNET_SEEDS, TESTNET3_SEEDS, TESTNET4_SEEDS};
 use tokio::net::UnixListener;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use wallet::silentpayments::Wallet;
 
 const TABLE_WIDTH: usize = 16;
 const TABLE_SLOT: usize = 16;
@@ -44,17 +43,66 @@ const STALE_BLOCK_DURATION: Duration = Duration::from_secs(60 * 20);
 
 configure_me::include_config!();
 
+fn scan_kernel_block(
+    chainman: &ChainstateManager,
+    kernel_block: &bitcoinkernel::Block,
+    entry: &bitcoinkernel::BlockTreeEntry,
+    wallet: &Arc<Mutex<Wallet>>,
+) {
+    let block_height = entry.height() as u32;
+
+    let spent_outputs = match chainman.read_spent_outputs(entry) {
+        Ok(u) => u,
+        Err(e) => {
+            warn!("read_spent_outputs failed at height {block_height}: {e}");
+            return;
+        }
+    };
+
+    let count = wallet
+        .lock()
+        .unwrap()
+        .scan_block(kernel_block, &spent_outputs, block_height);
+    if count > 0 {
+        info!(
+            "Wallet: found {} silent payment(s) at height {}",
+            count, block_height
+        );
+    }
+}
+
 fn create_context(
     chain_type: ChainType,
     shutdown_tx: mpsc::Sender<()>,
     tip_state: &Arc<Mutex<TipState>>,
+    wallet: Arc<Mutex<Wallet>>,
+    chainman_holder: Arc<std::sync::OnceLock<Arc<ChainstateManager>>>,
 ) -> Arc<Context> {
     let shutdown_triggered = Arc::new(AtomicBool::new(false));
     let shutdown_triggered_clone = Arc::clone(&shutdown_triggered);
     let shutdown_tx_clone = shutdown_tx.clone();
     let tip_state_clone = tip_state.clone();
+    let wallet_for_disconnect = Arc::clone(&wallet);
     Arc::new(ContextBuilder::new()
         .chain_type(chain_type)
+        .with_block_connected_validation(move |block: bitcoinkernel::Block, entry: bitcoinkernel::BlockTreeEntry<'_>| {
+            if wallet.lock().unwrap().keys.is_none() {
+                return;
+            }
+            let Some(chainman) = chainman_holder.get() else { return };
+            scan_kernel_block(chainman.as_ref(), &block, &entry, &wallet);
+        })
+        .with_block_disconnected_validation(move |block: bitcoinkernel::Block, entry: bitcoinkernel::BlockTreeEntry<'_>| {
+            if wallet_for_disconnect.lock().unwrap().keys.is_none() {
+                return;
+            }
+            let height = entry.height();
+            wallet_for_disconnect
+                .lock()
+                .unwrap()
+                .process_disconnect(&block);
+            info!("Wallet: disconnected block at height {}", height);
+        })
         .with_block_tip_notification(|state, hash: bitcoinkernel::BlockHash, _| {
                 let hash = BlockHash::from_byte_array(hash.into());
                 match state {
@@ -107,7 +155,7 @@ struct KernelLog {}
 impl Log for KernelLog {
     fn log(&self, message: &str) {
         log::info!(
-            target: "bitcoinkernel", 
+            target: "bitcoinkernel",
             "{}", message.strip_suffix("\r\n").or_else(|| message.strip_suffix('\n')).unwrap_or(message));
     }
 }
@@ -359,7 +407,16 @@ fn main() {
     let tip_state = Arc::new(Mutex::new(TipState::default()));
 
     let network = config.network.parse::<Network>().expect("invalid network");
-    let context = create_context(network.chain_type(), shutdown_tx.clone(), &tip_state);
+    let wallet = Arc::new(Mutex::new(Wallet::new(network.wallet_network())));
+    let chainman_holder: Arc<std::sync::OnceLock<Arc<ChainstateManager>>> =
+        Arc::new(std::sync::OnceLock::new());
+    let context = create_context(
+        network.chain_type(),
+        shutdown_tx.clone(),
+        &tip_state,
+        Arc::clone(&wallet),
+        Arc::clone(&chainman_holder),
+    );
 
     let data_dir = config.datadir.data_dir();
     let blocks_dir = data_dir.clone() + "/blocks";
@@ -371,6 +428,10 @@ fn main() {
                 .unwrap(),
         );
     let chainman = Arc::new(chainman_builder.build().unwrap());
+    chainman_holder
+        .set(Arc::clone(&chainman))
+        .ok()
+        .expect("chainman holder already set");
 
     let (block_tx, block_rx) = mpsc::sync_channel(1);
     let (addr_tx, addr_rx) = mpsc::channel();
@@ -403,6 +464,7 @@ fn main() {
         return;
     }
 
+    let wallet_for_ipc = Arc::clone(&wallet);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -427,6 +489,7 @@ fn main() {
                             }
                         };
                         info!("Handling inbound IPC call");
+                        let state = Arc::clone(&wallet_for_ipc);
                         let (reader, writer) = stream.into_split();
                         let buf_reader = futures::io::BufReader::new(reader.compat());
                         let buf_writer = futures::io::BufWriter::new(writer.compat_write());
@@ -437,7 +500,7 @@ fn main() {
                             Default::default(),
                         );
                         let client: server::Client =
-                            capnp_rpc::new_client(IpcInterface::new(ipc_shutdown.clone()));
+                            capnp_rpc::new_client(IpcInterface::new(ipc_shutdown.clone(), state));
                         let rpc_system =
                             capnp_rpc::RpcSystem::new(Box::new(network), Some(client.client));
                         tokio::task::spawn_local(rpc_system);

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,15 +1,19 @@
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex};
 
-use crate::server_capnp;
+use bitcoin::secp256k1::{Parity, PublicKey, SecretKey, XOnlyPublicKey};
+use wallet::silentpayments::{build_receiver, SilentPaymentKeys, Wallet};
+
+use crate::{server_capnp, wallet_capnp};
 
 #[derive(Debug)]
 pub struct IpcInterface {
     tx: mpsc::Sender<()>,
+    state: Arc<Mutex<Wallet>>,
 }
 
 impl IpcInterface {
-    pub fn new(tx: mpsc::Sender<()>) -> Self {
-        Self { tx }
+    pub fn new(tx: mpsc::Sender<()>, state: Arc<Mutex<Wallet>>) -> Self {
+        Self { tx, state }
     }
 }
 
@@ -33,6 +37,108 @@ impl server_capnp::server::Server for IpcInterface {
         self.tx
             .send(())
             .map_err(|_| capnp::Error::failed("could not shutdown server.".to_string()))?;
+        Ok(())
+    }
+
+    async fn make_wallet(
+        self: capnp::capability::Rc<Self>,
+        _: server_capnp::server::MakeWalletParams,
+        mut results: server_capnp::server::MakeWalletResults,
+    ) -> Result<(), capnp::Error> {
+        let client: wallet_capnp::wallet::Client =
+            capnp_rpc::new_client(WalletIpcInterface::new(self.state.clone()));
+        results.get().set_wallet(client);
+        Ok(())
+    }
+}
+
+pub struct WalletIpcInterface {
+    state: Arc<Mutex<Wallet>>,
+}
+
+impl WalletIpcInterface {
+    pub fn new(state: Arc<Mutex<Wallet>>) -> Self {
+        Self { state }
+    }
+}
+
+impl wallet_capnp::wallet::Server for WalletIpcInterface {
+    async fn import_keys(
+        self: capnp::capability::Rc<Self>,
+        params: wallet_capnp::wallet::ImportKeysParams,
+        mut results: wallet_capnp::wallet::ImportKeysResults,
+    ) -> Result<(), capnp::Error> {
+        let p = params.get()?;
+        let scan_bytes = p.get_scan_key()?;
+        let spend_bytes = p.get_spend_key()?;
+
+        let scan_key = SecretKey::from_slice(scan_bytes)
+            .map_err(|e| capnp::Error::failed(format!("invalid scan key: {e}")))?;
+        let spend_xonly = XOnlyPublicKey::from_slice(spend_bytes)
+            .map_err(|e| capnp::Error::failed(format!("invalid spend key: {e}")))?;
+        let spend_key = PublicKey::from_x_only_public_key(spend_xonly, Parity::Even);
+
+        let mut wallet = self.state.lock().unwrap();
+        let receiver = build_receiver(&scan_key, spend_key, wallet.network)
+            .map_err(|e| capnp::Error::failed(format!("invalid key pair: {e}")))?;
+
+        wallet.spend_key = Some(spend_key);
+        wallet.keys = Some(SilentPaymentKeys { receiver, scan_key });
+
+        results.get().set_ok(true);
+        results.get().set_message("keys imported");
+        Ok(())
+    }
+
+    async fn get_balance(
+        self: capnp::capability::Rc<Self>,
+        _: wallet_capnp::wallet::GetBalanceParams,
+        mut results: wallet_capnp::wallet::GetBalanceResults,
+    ) -> Result<(), capnp::Error> {
+        let wallet = self.state.lock().unwrap();
+        let balance = wallet.balance();
+        let scan_height = wallet.scan_height;
+        let utxo_count = wallet.utxo_count() as u32;
+        drop(wallet);
+
+        let mut r = results.get();
+        r.set_sats(balance.to_sat());
+        r.set_scan_height(scan_height);
+        r.set_utxo_count(utxo_count);
+        Ok(())
+    }
+
+    async fn get_history(
+        self: capnp::capability::Rc<Self>,
+        _: wallet_capnp::wallet::GetHistoryParams,
+        mut results: wallet_capnp::wallet::GetHistoryResults,
+    ) -> Result<(), capnp::Error> {
+        let wallet = self.state.lock().unwrap();
+        let history = wallet.history();
+        drop(wallet);
+
+        let text = history
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        results.get().set_entries(&text);
+        Ok(())
+    }
+
+    async fn receive(
+        self: capnp::capability::Rc<Self>,
+        _: wallet_capnp::wallet::ReceiveParams,
+        mut results: wallet_capnp::wallet::ReceiveResults,
+    ) -> Result<(), capnp::Error> {
+        let wallet = self.state.lock().unwrap();
+        let address = wallet
+            .receive_address()
+            .ok_or_else(|| capnp::Error::failed("no keys imported".to_string()))?;
+        drop(wallet);
+
+        results.get().set_address(&address);
         Ok(())
     }
 }

--- a/src/kernel_util.rs
+++ b/src/kernel_util.rs
@@ -1,6 +1,7 @@
 use bitcoin::{consensus::encode, hashes::Hash, Network};
-use bitcoinkernel::{core::BlockHashExt, BlockTreeEntry, ChainType};
+use bitcoinkernel::{core::BlockHashExt, Block as KernelBlock, BlockTreeEntry, ChainType};
 use std::{fs, path::PathBuf};
+use wallet::silentpayments::Network as WalletNetwork;
 
 pub trait ChainExt {
     fn chain_type(&self) -> ChainType;
@@ -48,6 +49,7 @@ impl<S: AsRef<str>> DirnameExt for S {
 pub trait NetworkExt {
     // The P2P port for a given [`Network`].
     fn default_p2p_port(self) -> u16;
+    fn wallet_network(self) -> WalletNetwork;
 }
 
 impl NetworkExt for Network {
@@ -61,6 +63,21 @@ impl NetworkExt for Network {
             Self::Regtest => 18444,
         }
     }
+
+    fn wallet_network(self) -> WalletNetwork {
+        match self {
+            Self::Bitcoin => WalletNetwork::Mainnet,
+            Self::Regtest => WalletNetwork::Regtest,
+            _ => WalletNetwork::Testnet,
+        }
+    }
+}
+
+pub fn kernel_block_to_bitcoin_block(block: &KernelBlock) -> bitcoin::Block {
+    let raw = block
+        .consensus_encode()
+        .expect("kernel block serialization");
+    encode::deserialize(&raw).expect("kernel block deserialization")
 }
 
 pub fn bitcoin_block_to_kernel_block(block: &bitcoin::Block) -> bitcoinkernel::Block {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod kernel_util;
 pub mod peer;
 
 capnp::generated_code!(pub mod server_capnp);
+capnp::generated_code!(pub mod wallet_capnp);


### PR DESCRIPTION
New PR using SPDK... Integrate BIP-352 silent payment scanning into kernel-node using the `silentpayments` crate from [SPDK](https://github.com/cygnet3/spdk).
- Add `crates/wallet` as a workspace member with a `silentpayments` submodule that wraps SPDK's cryptographic primitives
- Scan each accepted block for payments using kernel undo data to recover prevout scripts
- Track received UTXOs and balance in an in-memory wallet
- Expose `import_keys`, `balance`, and `history` over the existing `node.sock`