### PR TITLE
silent payments: file-based key import/export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +434,12 @@ name = "fmt2io"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b6129284da9f7e5296cc22183a63f24300e945e297705dcc0672f7df01d62c8"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures"
@@ -523,10 +541,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -580,13 +620,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -616,6 +664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "kernel-node"
 version = "0.1.0"
 dependencies = [
@@ -637,6 +691,12 @@ dependencies = [
  "tokio-util",
  "wallet",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbitcoinkernel-sys"
@@ -663,6 +723,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -711,6 +777,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -777,6 +849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,7 +881,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -848,6 +926,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +957,12 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -895,6 +992,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -967,6 +1077,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1081,6 +1204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1229,7 @@ dependencies = [
  "bitcoinkernel",
  "log",
  "silentpayments",
+ "tempfile",
 ]
 
 [[package]]
@@ -1107,6 +1237,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi-util"
@@ -1142,6 +1324,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,3 +1436,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -21,3 +21,9 @@ name = "daemon"
 type = "bool"
 default = "false"
 doc = "Run the server as a daemon"
+
+[[param]]
+name = "sp_keys_file"
+type = "String"
+optional = true
+doc = "Path to a binary silent payments keys file to import at startup."

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -8,3 +8,6 @@ silentpayments = { version = "0.5", features = ["receiving", "encode"] }
 bitcoin = "0.32.8"
 bitcoinkernel = "0.2"
 log = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/wallet/src/io.rs
+++ b/crates/wallet/src/io.rs
@@ -1,0 +1,7 @@
+use std::{io, path::Path};
+
+pub trait FileExt: Sized {
+    type Error: From<io::Error>;
+    fn save(&self, path: &Path) -> Result<(), Self::Error>;
+    fn load(path: &Path) -> Result<Self, Self::Error>;
+}

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod io;
 pub mod silentpayments;

--- a/crates/wallet/src/silentpayments/keys_file.rs
+++ b/crates/wallet/src/silentpayments/keys_file.rs
@@ -1,0 +1,236 @@
+use std::{
+    fs,
+    io::{self, Write},
+    path::Path,
+};
+
+use bitcoin::secp256k1::{self, Secp256k1, SecretKey, XOnlyPublicKey};
+
+use crate::io::FileExt;
+
+const MAGIC: &[u8; 4] = b"SPKF";
+const KEY_LEN: usize = 32;
+const TAG_LEN: usize = 1;
+const FILE_LEN: usize = MAGIC.len() + KEY_LEN + TAG_LEN + KEY_LEN;
+
+const SPEND_TAG_SECRET: u8 = 0;
+const SPEND_TAG_XONLY_PUB: u8 = 1;
+
+/// `Secret` for software wallets. `XOnlyPublic` for hardware-signer / watch-only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpendKey {
+    Secret(SecretKey),
+    XOnlyPublic(XOnlyPublicKey),
+}
+
+impl SpendKey {
+    pub fn xonly(&self) -> XOnlyPublicKey {
+        match self {
+            SpendKey::Secret(sk) => {
+                let secp = Secp256k1::signing_only();
+                sk.public_key(&secp).x_only_public_key().0
+            }
+            SpendKey::XOnlyPublic(pk) => *pk,
+        }
+    }
+}
+
+/// On-disk format: 4-byte magic `SPKF` (Silent Payment Key File), 32-byte scan
+/// secret, 1-byte spend tag, 32-byte spend material. 69 bytes total.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SilentPaymentKeysFile {
+    pub scan_key: SecretKey,
+    pub spend: SpendKey,
+}
+
+#[derive(Debug)]
+pub enum KeysFileError {
+    Io(io::Error),
+    BadMagic,
+    WrongLength { expected: usize, actual: usize },
+    UnknownSpendTag(u8),
+    InvalidKey(secp256k1::Error),
+}
+
+impl std::fmt::Display for KeysFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeysFileError::Io(e) => write!(f, "i/o error: {e}"),
+            KeysFileError::BadMagic => write!(f, "bad magic: not a silent payments keys file"),
+            KeysFileError::WrongLength { expected, actual } => write!(
+                f,
+                "wrong file length: expected {expected} bytes, got {actual}"
+            ),
+            KeysFileError::UnknownSpendTag(t) => write!(f, "unknown spend tag: {t}"),
+            KeysFileError::InvalidKey(e) => write!(f, "invalid key: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for KeysFileError {}
+
+impl From<io::Error> for KeysFileError {
+    fn from(e: io::Error) -> Self {
+        KeysFileError::Io(e)
+    }
+}
+
+impl From<secp256k1::Error> for KeysFileError {
+    fn from(e: secp256k1::Error) -> Self {
+        KeysFileError::InvalidKey(e)
+    }
+}
+
+impl SilentPaymentKeysFile {
+    pub fn new(scan_key: SecretKey, spend: SpendKey) -> Self {
+        Self { scan_key, spend }
+    }
+
+    pub fn spend_xonly(&self) -> XOnlyPublicKey {
+        self.spend.xonly()
+    }
+
+    pub fn to_bytes(&self) -> [u8; FILE_LEN] {
+        let mut buf = [0u8; FILE_LEN];
+        let mut off = 0;
+        buf[off..off + MAGIC.len()].copy_from_slice(MAGIC);
+        off += MAGIC.len();
+        buf[off..off + KEY_LEN].copy_from_slice(&self.scan_key.secret_bytes());
+        off += KEY_LEN;
+        match &self.spend {
+            SpendKey::Secret(sk) => {
+                buf[off] = SPEND_TAG_SECRET;
+                buf[off + TAG_LEN..].copy_from_slice(&sk.secret_bytes());
+            }
+            SpendKey::XOnlyPublic(pk) => {
+                buf[off] = SPEND_TAG_XONLY_PUB;
+                buf[off + TAG_LEN..].copy_from_slice(&pk.serialize());
+            }
+        }
+        buf
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KeysFileError> {
+        if bytes.len() != FILE_LEN {
+            return Err(KeysFileError::WrongLength {
+                expected: FILE_LEN,
+                actual: bytes.len(),
+            });
+        }
+        let body = bytes
+            .strip_prefix(MAGIC.as_slice())
+            .ok_or(KeysFileError::BadMagic)?;
+        let scan_key = SecretKey::from_slice(&body[..KEY_LEN])?;
+        let tag = body[KEY_LEN];
+        let spend_bytes = &body[KEY_LEN + TAG_LEN..];
+        let spend = match tag {
+            SPEND_TAG_SECRET => SpendKey::Secret(SecretKey::from_slice(spend_bytes)?),
+            SPEND_TAG_XONLY_PUB => SpendKey::XOnlyPublic(XOnlyPublicKey::from_slice(spend_bytes)?),
+            other => return Err(KeysFileError::UnknownSpendTag(other)),
+        };
+        Ok(Self { scan_key, spend })
+    }
+}
+
+impl FileExt for SilentPaymentKeysFile {
+    type Error = KeysFileError;
+
+    /// Refuses to overwrite (`AlreadyExists`).
+    fn save(&self, path: &Path) -> Result<(), Self::Error> {
+        let mut file = fs::File::create_new(path)?;
+        file.write_all(&self.to_bytes())?;
+        Ok(())
+    }
+
+    fn load(path: &Path) -> Result<Self, Self::Error> {
+        let bytes = fs::read(path)?;
+        Self::from_bytes(&bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_keys() -> (SecretKey, SecretKey) {
+        let scan = SecretKey::from_slice(&[1u8; 32]).expect("valid scan key");
+        let spend = SecretKey::from_slice(&[2u8; 32]).expect("valid spend key");
+        (scan, spend)
+    }
+
+    fn xonly_from(sk: SecretKey) -> XOnlyPublicKey {
+        sk.public_key(&Secp256k1::signing_only())
+            .x_only_public_key()
+            .0
+    }
+
+    #[test]
+    fn roundtrip_preserves_secret_variant() {
+        let (scan, spend) = test_keys();
+        let original = SilentPaymentKeysFile::new(scan, SpendKey::Secret(spend));
+        let bytes = original.to_bytes();
+        let decoded = SilentPaymentKeysFile::from_bytes(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn roundtrip_preserves_xonly_public_variant() {
+        let (scan, spend) = test_keys();
+        let xonly = xonly_from(spend);
+        let original = SilentPaymentKeysFile::new(scan, SpendKey::XOnlyPublic(xonly));
+        let bytes = original.to_bytes();
+        let decoded = SilentPaymentKeysFile::from_bytes(&bytes).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn from_bytes_rejects_bad_magic() {
+        let (scan, spend) = test_keys();
+        let mut bytes = b"XXXX".to_vec();
+        bytes.extend_from_slice(&scan.secret_bytes());
+        bytes.push(SPEND_TAG_SECRET);
+        bytes.extend_from_slice(&spend.secret_bytes());
+        assert!(matches!(
+            SilentPaymentKeysFile::from_bytes(&bytes),
+            Err(KeysFileError::BadMagic)
+        ));
+    }
+
+    #[test]
+    fn from_bytes_rejects_unknown_spend_tag() {
+        let (scan, spend) = test_keys();
+        let mut bytes = MAGIC.to_vec();
+        bytes.extend_from_slice(&scan.secret_bytes());
+        bytes.push(99);
+        bytes.extend_from_slice(&spend.secret_bytes());
+        assert!(matches!(
+            SilentPaymentKeysFile::from_bytes(&bytes),
+            Err(KeysFileError::UnknownSpendTag(99))
+        ));
+    }
+
+    #[test]
+    fn save_load_roundtrips_through_disk() {
+        let (scan, spend) = test_keys();
+        let original = SilentPaymentKeysFile::new(scan, SpendKey::Secret(spend));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("keys.bin");
+        original.save(&path).expect("save");
+        let decoded = SilentPaymentKeysFile::load(&path).expect("load");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn save_refuses_to_overwrite_existing_file() {
+        let (scan, spend) = test_keys();
+        let file = SilentPaymentKeysFile::new(scan, SpendKey::Secret(spend));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("keys.bin");
+        file.save(&path).expect("first save");
+        let err = file.save(&path).expect_err("second save must fail");
+        assert!(
+            matches!(&err, KeysFileError::Io(e) if e.kind() == io::ErrorKind::AlreadyExists),
+            "expected Io(AlreadyExists), got {err:?}"
+        );
+    }
+}

--- a/crates/wallet/src/silentpayments/mod.rs
+++ b/crates/wallet/src/silentpayments/mod.rs
@@ -1,8 +1,10 @@
+mod keys_file;
 mod scanning;
 mod wallet;
 
 pub use ::silentpayments::receiving::{Label, Receiver};
 pub use ::silentpayments::{Network, SilentPaymentAddress};
+pub use keys_file::{SilentPaymentKeysFile, SpendKey};
 pub use scanning::{scan_transaction, InputData};
 pub use wallet::{Coin, HistoryEntry, SilentPaymentKeys, SpentBy, Wallet};
 

--- a/crates/wallet/src/silentpayments/wallet.rs
+++ b/crates/wallet/src/silentpayments/wallet.rs
@@ -3,12 +3,12 @@ use std::{
     fmt,
 };
 
-use bitcoin::secp256k1::{PublicKey, Scalar, SecretKey};
+use bitcoin::secp256k1::{Parity, PublicKey, Scalar, SecretKey, XOnlyPublicKey};
 use bitcoin::{hashes::Hash, Amount, OutPoint, ScriptBuf, Txid};
 use bitcoinkernel::prelude::{TransactionExt, TxInExt, TxOutPointExt, TxidExt};
 
 use crate::silentpayments::scanning::scan_block_inner;
-use crate::silentpayments::{Label, Network, Receiver};
+use crate::silentpayments::{build_receiver, Label, Network, Receiver};
 
 #[derive(Debug)]
 pub struct SilentPaymentKeys {
@@ -94,6 +94,18 @@ impl Wallet {
             network,
             utxos: HashMap::new(),
         }
+    }
+
+    pub fn import_keys(
+        &mut self,
+        scan_key: SecretKey,
+        spend_xonly: XOnlyPublicKey,
+    ) -> Result<(), ::silentpayments::Error> {
+        let spend_pub = PublicKey::from_x_only_public_key(spend_xonly, Parity::Even);
+        let receiver = build_receiver(&scan_key, spend_pub, self.network)?;
+        self.spend_key = Some(spend_pub);
+        self.keys = Some(SilentPaymentKeys { receiver, scan_key });
+        Ok(())
     }
 
     pub fn scan_block(

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::{rand::rngs::OsRng, Secp256k1, SecretKey, XOnlyPublicKey};
 use clap::Parser;
@@ -5,6 +7,8 @@ use kernel_node::ext::DirnameExt;
 use kernel_node::server_capnp::server;
 use tokio::net::UnixStream;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use wallet::io::FileExt;
+use wallet::silentpayments::{SilentPaymentKeysFile, SpendKey};
 
 const DEFAULT_DATA_DIR: &str = "~/.kernel-node/";
 
@@ -45,10 +49,16 @@ struct Echo {
 enum WalletCmd {
     /// Generate fresh scan and spend keys for receiving silent payments.
     ///
-    /// Prints the scan private key, spend private key, and spend x-only public
-    /// key as hex on stdout. WARNING: scan_key and spend_priv must be kept secret
-    /// — anyone with them can spend received funds.
-    GenerateKeys,
+    /// By default, prints the scan key, spend private key, and spend
+    /// x-only public key as hex on stdout. With `--out <path>`, writes
+    /// the secrets to a binary file and prints only the spend public
+    /// key on stderr. WARNING: anyone with the scan key and spend
+    /// private key can spend received funds.
+    GenerateKeys {
+        /// Write the keys to this binary file. Must not already exist.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Import BIP-352 silent payment keys to enable scanning for incoming payments.
     ///
     /// Both keys are hex-encoded. The scan key derives the ECDH shared secret with
@@ -98,12 +108,22 @@ async fn connect_server(datadir_path: &str) -> server::Client {
 fn main() {
     let cli = Args::parse();
 
-    if let Commands::Wallet(WalletCmd::GenerateKeys) = &cli.commands {
+    if let Commands::Wallet(WalletCmd::GenerateKeys { out }) = &cli.commands {
         let (scan_priv, spend_priv, spend_pub) = generate_keys();
-        eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
-        println!("scan_key={}", scan_priv.display_secret());
-        println!("spend_priv={}", spend_priv.display_secret());
-        println!("spend_pub={}", spend_pub);
+        match out {
+            Some(path) => {
+                let file = SilentPaymentKeysFile::new(scan_priv, SpendKey::Secret(spend_priv));
+                file.save(path).expect("failed to write keys file");
+                eprintln!("Wrote silent payment keys to {}", path.display());
+                eprintln!("spend_pub={}", spend_pub);
+            }
+            None => {
+                eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
+                println!("scan_key={}", scan_priv.display_secret());
+                println!("spend_priv={}", spend_priv.display_secret());
+                println!("spend_pub={}", spend_pub);
+            }
+        }
         return;
     }
 
@@ -139,7 +159,7 @@ fn main() {
                 let wallet_response = client.make_wallet_request().send().promise.await.unwrap();
                 let client = wallet_response.get().unwrap().get_wallet().unwrap();
                 match cmd {
-                    WalletCmd::GenerateKeys => unreachable!("handled before runtime"),
+                    WalletCmd::GenerateKeys { .. } => unreachable!("handled before runtime"),
                     WalletCmd::ImportKeys {
                         scan_key,
                         spend_key,

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -32,7 +32,8 @@ use log::{debug, error, info, warn};
 use p2p::dns::{BITCOIN_SEEDS, SIGNET_SEEDS, TESTNET3_SEEDS, TESTNET4_SEEDS};
 use tokio::net::UnixListener;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-use wallet::silentpayments::Wallet;
+use wallet::io::FileExt;
+use wallet::silentpayments::{SilentPaymentKeysFile, Wallet};
 
 const TABLE_WIDTH: usize = 16;
 const TABLE_SLOT: usize = 16;
@@ -444,6 +445,18 @@ fn run(
     Ok(())
 }
 
+fn auto_import_keys(wallet: &mut Wallet, path: &str) {
+    let file = SilentPaymentKeysFile::load(std::path::Path::new(path))
+        .unwrap_or_else(|e| panic!("Failed to load silent payment keys from {path}: {e}"));
+    wallet
+        .import_keys(file.scan_key, file.spend_xonly())
+        .unwrap_or_else(|e| panic!("Failed to build silent payment receiver from {path}: {e}"));
+    info!(
+        target: Category::NODE,
+        "Imported silent payment keys from {path}"
+    );
+}
+
 fn main() {
     let (config, _) = Config::including_optional_config_files::<&[&str]>(&[]).unwrap_or_exit();
     START.call_once(|| {
@@ -462,6 +475,9 @@ fn main() {
 
     let network = config.network.parse::<Network>().expect("invalid network");
     let wallet = Arc::new(Mutex::new(Wallet::new(network.wallet_network())));
+    if let Some(path) = config.sp_keys_file.as_ref() {
+        auto_import_keys(&mut wallet.lock().unwrap(), path);
+    }
     let chainman_holder: Arc<std::sync::OnceLock<Arc<ChainstateManager>>> =
         Arc::new(std::sync::OnceLock::new());
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,7 +1,7 @@
 use std::sync::{mpsc, Arc, Mutex};
 
-use bitcoin::secp256k1::{Parity, PublicKey, SecretKey, XOnlyPublicKey};
-use wallet::silentpayments::{build_receiver, SilentPaymentKeys, Wallet};
+use bitcoin::secp256k1::{SecretKey, XOnlyPublicKey};
+use wallet::silentpayments::Wallet;
 
 use crate::{server_capnp, wallet_capnp};
 
@@ -76,14 +76,11 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
             .map_err(|e| capnp::Error::failed(format!("invalid scan key: {e}")))?;
         let spend_xonly = XOnlyPublicKey::from_slice(spend_bytes)
             .map_err(|e| capnp::Error::failed(format!("invalid spend key: {e}")))?;
-        let spend_key = PublicKey::from_x_only_public_key(spend_xonly, Parity::Even);
 
         let mut wallet = self.state.lock().unwrap();
-        let receiver = build_receiver(&scan_key, spend_key, wallet.network)
+        wallet
+            .import_keys(scan_key, spend_xonly)
             .map_err(|e| capnp::Error::failed(format!("invalid key pair: {e}")))?;
-
-        wallet.spend_key = Some(spend_key);
-        wallet.keys = Some(SilentPaymentKeys { receiver, scan_key });
 
         results.get().set_ok(true);
         results.get().set_message("keys imported");


### PR DESCRIPTION
Implements file imports from #55:

- `wallet::io::FileExt` trait that carries `save`/`load` so file-backed types can reuse the path handling.
- `wallet generate-keys --out <path>` writes a binary keys file (mode 0o600 on Unix, refuses to overwrite).
- `wallet import-keys-file <path>` reads it back.
- `--sp-keys-file <path>` (node option) auto-imports on startup; load errors warn and continue.
