### PR TITLE
Establish feeler connections and add transaction broadcast

### DIFF
--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -5,4 +5,5 @@ interface Wallet {
     getBalance  @1 () -> (sats :UInt64, scanHeight :UInt32, utxoCount :UInt32);
     getHistory  @2 () -> (entries :Text);
     receive     @3 () -> (address :Text);
+    broadcastRawTx @4 (tx :Data) -> (txid :Text);
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -75,6 +75,11 @@ enum WalletCmd {
     History,
     /// Show the silent payment address the wallet is scanning for.
     Receive,
+    /// Broadcast a raw transaction to the network.
+    BroadcastRawTx {
+        /// Hex-encoded raw transaction.
+        tx: String,
+    },
 }
 
 fn generate_keys() -> (SecretKey, SecretKey, XOnlyPublicKey) {
@@ -205,6 +210,15 @@ fn main() {
                         let r = result.get().unwrap();
                         let address = r.get_address().unwrap().to_string().unwrap();
                         println!("{}", address);
+                    }
+                    WalletCmd::BroadcastRawTx { tx } => {
+                        let raw_bytes = Vec::<u8>::from_hex(&tx).expect("tx must be valid hex");
+                        let mut req = client.broadcast_raw_tx_request();
+                        req.get().set_tx(&raw_bytes);
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let txid = r.get_txid().unwrap().to_string().unwrap();
+                        println!("{}", txid);
                     }
                 }
             }

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -12,9 +12,10 @@ use std::{
 
 use bitcoin::p2p::{
     address::{AddrV2, AddrV2Message},
+    message::NetworkMessage,
     ServiceFlags,
 };
-use bitcoin::{hashes::Hash, BlockHash, Network};
+use bitcoin::{hashes::Hash, BlockHash, Network, Transaction};
 use bitcoinkernel::{
     core::BlockHashExt, prelude::BlockValidationStateExt, ChainType, ChainstateManager,
     ChainstateManagerBuilder, Context, ContextBuilder, Log, Logger, SynchronizationState,
@@ -47,6 +48,8 @@ const MAX_BUCKETS: usize = 4;
 const DNS_RESOLVER: IpAddr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
 
 const STALE_BLOCK_DURATION: Duration = Duration::from_secs(60 * 20);
+
+const BROADCAST_TIMEOUT: Duration = Duration::from_secs(60);
 
 configure_me::include_config!();
 
@@ -182,6 +185,49 @@ fn open_feeler(table: &mut addrman::Table<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>,
     }
 }
 
+fn broadcast_transaction(
+    table: &mut addrman::Table<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>,
+    network: Network,
+    tx: &Transaction,
+) {
+    let start = Instant::now();
+    loop {
+        if start.elapsed() >= BROADCAST_TIMEOUT {
+            warn!(target: Category::NODE, "Timed out attempting to broadcast transaction");
+            return;
+        }
+        let Some(record) = table.select() else {
+            return;
+        };
+        let (addr, port) = record.network_addr();
+        let socket_addr = match addr {
+            AddrV2::Ipv6(ipv6) => SocketAddr::new(IpAddr::V6(ipv6), port),
+            AddrV2::Ipv4(ipv4) => SocketAddr::new(IpAddr::V4(ipv4), port),
+            _ => continue,
+        };
+        let conf = ConnectionConfig::new()
+            .change_network(network)
+            .offer_services(ServiceFlags::WITNESS)
+            .user_agent("/kernel-node:0.1.0/".into());
+        match conf.open_connection(socket_addr, TimeoutParams::new()) {
+            Ok((writer, _, _)) => match writer.send_message(NetworkMessage::Tx(tx.clone())) {
+                Ok(_) => {
+                    info!(target: Category::NODE, "Broadcast transaction to {:?}", socket_addr);
+                    table.successful_connection(&record);
+                    return;
+                }
+                Err(e) => {
+                    warn!(target: Category::NODE, "Failed to send transaction to {:?}: {}", socket_addr, e);
+                }
+            },
+            Err(_) => {
+                info!(target: Category::NODE, "Failed broadcast connection to {:?}", socket_addr);
+                table.failed_connection(&record);
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run(
     network: Network,
@@ -191,6 +237,7 @@ fn run(
     addr_rx: mpsc::Receiver<Vec<AddrV2Message>>,
     block_rx: mpsc::Receiver<bitcoinkernel::Block>,
     scan_rx: mpsc::Receiver<ScanEvent>,
+    broadcast_rx: mpsc::Receiver<Transaction>,
     wallet: Arc<Mutex<Wallet>>,
 ) -> std::io::Result<()> {
     let mut table = addrman::Table::<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>::new();
@@ -385,11 +432,17 @@ fn run(
     let feeler_thread = std::thread::spawn(move || {
         info!(target: Category::NODE, "Starting feeler thread.");
         while running_feelers.load(Ordering::SeqCst) {
-            {
-                let mut table = addrman_for_feelers.lock().unwrap();
-                open_feeler(table.deref_mut(), network);
+            match broadcast_rx.recv_timeout(Duration::from_secs(30)) {
+                Ok(tx) => {
+                    let mut table = addrman_for_feelers.lock().unwrap();
+                    broadcast_transaction(table.deref_mut(), network, &tx);
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    let mut table = addrman_for_feelers.lock().unwrap();
+                    open_feeler(table.deref_mut(), network);
+                }
+                Err(RecvTimeoutError::Disconnected) => break,
             }
-            std::thread::sleep(Duration::from_secs(30));
         }
     });
 
@@ -477,6 +530,7 @@ fn main() {
 
     let (block_tx, block_rx) = mpsc::sync_channel(1);
     let (addr_tx, addr_rx) = mpsc::channel();
+    let (broadcast_tx, broadcast_rx) = mpsc::sync_channel::<Transaction>(1);
 
     let node_state = NodeState {
         addr_tx,
@@ -541,8 +595,11 @@ fn main() {
                             capnp_rpc::rpc_twoparty_capnp::Side::Server,
                             Default::default(),
                         );
-                        let client: server::Client =
-                            capnp_rpc::new_client(IpcInterface::new(ipc_shutdown.clone(), state));
+                        let client: server::Client = capnp_rpc::new_client(IpcInterface::new(
+                            ipc_shutdown.clone(),
+                            broadcast_tx.clone(),
+                            state,
+                        ));
                         let rpc_system =
                             capnp_rpc::RpcSystem::new(Box::new(network), Some(client.client));
                         tokio::task::spawn_local(rpc_system);
@@ -560,6 +617,7 @@ fn main() {
         addr_rx,
         block_rx,
         scan_rx,
+        broadcast_rx,
         wallet,
     )
     .unwrap();

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -31,6 +31,10 @@ use kernel_node::{
     FatalShutdown, ScanEvent,
 };
 use log::{debug, error, info, warn};
+use p2p::{
+    handshake::ConnectionConfig,
+    net::{ConnectionExt, TimeoutParams},
+};
 use tokio::net::UnixListener;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use wallet::io::FileExt;
@@ -152,6 +156,32 @@ fn setup_logging() {
     unsafe { GLOBAL_LOG_CALLBACK_HOLDER = Some(Logger::new(KernelLog {}).unwrap()) };
 }
 
+fn open_feeler(table: &mut addrman::Table<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>, network: Network) {
+    if let Some(record) = table.select() {
+        let (addr, port) = record.network_addr();
+        let socket_addr = match addr {
+            AddrV2::Ipv6(ipv6) => SocketAddr::new(IpAddr::V6(ipv6), port),
+            AddrV2::Ipv4(ipv4) => SocketAddr::new(IpAddr::V4(ipv4), port),
+            _ => return,
+        };
+        let conf = ConnectionConfig::new()
+            .change_network(network)
+            .set_service_requirement(ServiceFlags::NETWORK)
+            .offer_services(ServiceFlags::WITNESS)
+            .user_agent("/kernel-node:0.1.0/".into());
+        match conf.open_connection(socket_addr, TimeoutParams::new()) {
+            Ok(_) => {
+                info!(target: Category::NODE, "Successful feeler connection opened to {:?}", socket_addr);
+                table.successful_connection(&record);
+            }
+            Err(_) => {
+                info!(target: Category::NODE, "Failed feeler connection to {:?}", socket_addr);
+                table.failed_connection(&record);
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run(
     network: Network,
@@ -208,12 +238,14 @@ fn run(
     let chainman = Arc::clone(&node_state.chainman);
     let context = Arc::clone(&node_state.context);
     let addrman = Arc::new(Mutex::new(table));
+    let addrman_for_feelers = Arc::clone(&addrman);
 
     let running = Arc::new(AtomicBool::new(true));
     let running_addr = running.clone();
     let running_peer = running.clone();
     let running_block = running.clone();
     let running_scan = running.clone();
+    let running_feelers = running.clone();
 
     let peer_source = Arc::clone(&addrman);
     let kill = Arc::new(Mutex::new(None));
@@ -223,20 +255,19 @@ fn run(
     let peer_processing_handler = thread::spawn(move || {
         info!(target: Category::NODE, "Starting net processing thread.");
         while running_peer.load(Ordering::SeqCst) {
-            let addr_lock = peer_source.lock().unwrap();
-            let (address, port) = addr_lock.select().unwrap().network_addr();
-            let peer = match address {
-                AddrV2::Ipv4(ipv4) => BitcoinPeer::new(
-                    SocketAddr::V4(SocketAddrV4::new(ipv4, port)),
-                    network,
-                    &mut node_state,
-                ),
-                AddrV2::Ipv6(ipv6) => {
-                    let socket_adrr = (ipv6, port).into();
-                    BitcoinPeer::new(socket_adrr, network, &mut node_state)
+            let socket_addr = {
+                let addr_lock = peer_source.lock().unwrap();
+                let (address, port) = addr_lock.select().unwrap().network_addr();
+                match address {
+                    AddrV2::Ipv4(ipv4) => Some(SocketAddr::V4(SocketAddrV4::new(ipv4, port))),
+                    AddrV2::Ipv6(ipv6) => Some(SocketAddr::from((ipv6, port))),
+                    _ => None,
                 }
-                _ => continue,
             };
+            let Some(socket_addr) = socket_addr else {
+                continue;
+            };
+            let peer = BitcoinPeer::new(socket_addr, network, &mut node_state);
             let mut peer = match peer {
                 Ok(connection) => {
                     let mut writer_lock = writer.lock().unwrap();
@@ -351,6 +382,17 @@ fn run(
         info!(target: Category::NODE, "Stopping scan thread.");
     });
 
+    let feeler_thread = std::thread::spawn(move || {
+        info!(target: Category::NODE, "Starting feeler thread.");
+        while running_feelers.load(Ordering::SeqCst) {
+            {
+                let mut table = addrman_for_feelers.lock().unwrap();
+                open_feeler(table.deref_mut(), network);
+            }
+            std::thread::sleep(Duration::from_secs(30));
+        }
+    });
+
     if let Ok(()) = shutdown_rx.recv() {
         context.interrupt().unwrap();
         let mut peer_lock = kill.lock().unwrap();
@@ -365,6 +407,7 @@ fn run(
     peer_processing_handler.join().unwrap();
     block_processing_handler.join().unwrap();
     scan_processing_handler.join().unwrap();
+    feeler_thread.join().unwrap();
 
     info!(target: Category::NODE, "Exiting.");
     Ok(())

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,6 +1,8 @@
 use std::sync::{mpsc, Arc, Mutex};
 
+use bitcoin::consensus::Decodable;
 use bitcoin::secp256k1::{SecretKey, XOnlyPublicKey};
+use bitcoin::Transaction;
 use wallet::silentpayments::Wallet;
 
 use crate::{server_capnp, wallet_capnp};
@@ -8,12 +10,21 @@ use crate::{server_capnp, wallet_capnp};
 #[derive(Debug)]
 pub struct IpcInterface {
     tx: mpsc::Sender<()>,
+    broadcast_tx: mpsc::SyncSender<Transaction>,
     state: Arc<Mutex<Wallet>>,
 }
 
 impl IpcInterface {
-    pub fn new(tx: mpsc::Sender<()>, state: Arc<Mutex<Wallet>>) -> Self {
-        Self { tx, state }
+    pub fn new(
+        tx: mpsc::Sender<()>,
+        broadcast_tx: mpsc::SyncSender<Transaction>,
+        state: Arc<Mutex<Wallet>>,
+    ) -> Self {
+        Self {
+            tx,
+            broadcast_tx,
+            state,
+        }
     }
 }
 
@@ -45,8 +56,10 @@ impl server_capnp::server::Server for IpcInterface {
         _: server_capnp::server::MakeWalletParams,
         mut results: server_capnp::server::MakeWalletResults,
     ) -> Result<(), capnp::Error> {
-        let client: wallet_capnp::wallet::Client =
-            capnp_rpc::new_client(WalletIpcInterface::new(self.state.clone()));
+        let client: wallet_capnp::wallet::Client = capnp_rpc::new_client(WalletIpcInterface::new(
+            self.state.clone(),
+            self.broadcast_tx.clone(),
+        ));
         results.get().set_wallet(client);
         Ok(())
     }
@@ -54,11 +67,15 @@ impl server_capnp::server::Server for IpcInterface {
 
 pub struct WalletIpcInterface {
     state: Arc<Mutex<Wallet>>,
+    broadcast_tx: mpsc::SyncSender<Transaction>,
 }
 
 impl WalletIpcInterface {
-    pub fn new(state: Arc<Mutex<Wallet>>) -> Self {
-        Self { state }
+    pub fn new(state: Arc<Mutex<Wallet>>, broadcast_tx: mpsc::SyncSender<Transaction>) -> Self {
+        Self {
+            state,
+            broadcast_tx,
+        }
     }
 }
 
@@ -136,6 +153,22 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         drop(wallet);
 
         results.get().set_address(&address);
+        Ok(())
+    }
+
+    async fn broadcast_raw_tx(
+        self: capnp::capability::Rc<Self>,
+        params: wallet_capnp::wallet::BroadcastRawTxParams,
+        mut results: wallet_capnp::wallet::BroadcastRawTxResults,
+    ) -> Result<(), capnp::Error> {
+        let mut raw = params.get()?.get_tx()?;
+        let tx = Transaction::consensus_decode(&mut raw)
+            .map_err(|e| capnp::Error::failed(format!("invalid transaction: {e}")))?;
+        let txid = tx.compute_txid().to_string();
+        self.broadcast_tx
+            .try_send(tx)
+            .map_err(|e| capnp::Error::failed(format!("broadcast unavailable: {e}")))?;
+        results.get().set_txid(&txid);
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request is two fold, but is grouped together as both connection types can use a single thread. In commit one, "feeler" connections are established, which are periodic connections that test the liveliness of peers. This makes finding new connections easier, as we are learning which peers are available even as we maintain long term connections. Commit two uses this same thread, however instead of opening a feeler, if there is a transaction available for broadcast we send it to a random peer then drop the connection. I consider this the "minimum viable product" to get started, but some things to add in the future would be to 1. use the usual `inv -> getdata -> tx` message flow 2. maintain a queue of TXIDs we gossiped, and list for inbound gossip from the long-lived connection to confirm the transaction propagated.

This is mostly an attempt to the get scaffolding ready for when we add sending (+ signing) in #55 