### PR TITLE
draft: use SRD coin-selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,10 +62,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
+name = "arbitrary"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arrayvec"
@@ -75,19 +75,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "8f1cba749a07c1efb1f4d87518f39cea4aec25d0991fb97e80459c057238f0d2"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.2",
 ]
-
-[[package]]
-name = "bdk_coin_select"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43064fa3dd1d3a8b24079cfcb5ede6b785857edc782277f17a1736511ccc1916"
 
 [[package]]
 name = "bech32"
@@ -109,16 +102,16 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "a1a121ccf1177a09084bd6ce97c52119919aac08ea3649967958eae41beceebf"
 dependencies = [
+ "arbitrary",
  "base58ck",
  "bech32 0.11.1",
- "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.2",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
@@ -134,10 +127,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-coin-selection"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "d7b982ab1395dad3399d4fbbf61a1778e7e2a3b10afad4e6af3a2ad5057a8235"
+dependencies = [
+ "bitcoin",
+ "rand",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -155,11 +152,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+checksum = "c202276cab20ab02cf6cc9d4df0d4284f7c784031619d3842236de8bc2bd5c6c"
 dependencies = [
- "bitcoin-internals",
+ "arbitrary",
 ]
 
 [[package]]
@@ -173,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "4ed83caece3afc59919481b33b472e1432d1abc4641ed9100be142ef5110b406"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
@@ -192,21 +189,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "capnp"
-version = "0.25.4"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63da65e5e9ffc3b8f993d4ad222a548152549351a643f6b850a7773cb6ff2809"
+checksum = "4777a3bc19b8f8e5fb2d0196c6b5dfcbbcc8b2fe08ae57f873f2f35f15cfc210"
 dependencies = [
  "embedded-io",
 ]
@@ -254,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -396,12 +393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b6129284da9f7e5296cc22183a63f24300e945e297705dcc0672f7df01d62c8"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,31 +493,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -574,21 +554,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -607,12 +579,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kernel-node"
@@ -638,12 +604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libbitcoinkernel-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,9 +626,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "man"
@@ -681,15 +641,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -736,16 +696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -804,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -827,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "roff"
@@ -856,7 +806,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.2",
  "rand",
  "secp256k1-sys",
 ]
@@ -869,12 +819,6 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -907,19 +851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.150"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -966,9 +897,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
@@ -982,9 +913,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -998,7 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1015,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "libc",
  "mio",
@@ -1111,15 +1042,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "utf8parse"
@@ -1137,8 +1062,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 name = "wallet"
 version = "0.1.0"
 dependencies = [
- "bdk_coin_select",
  "bitcoin",
+ "bitcoin-coin-selection",
  "bitcoinkernel",
  "log",
  "silentpayments",
@@ -1150,58 +1075,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
 
 [[package]]
 name = "winapi-util"
@@ -1237,121 +1110,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -8,7 +8,7 @@ silentpayments = { version = "0.5", features = ["receiving", "encode", "sending"
 bitcoin = { version = "0.32.8", features = ["rand-std"] }
 bitcoinkernel = "0.2"
 log = "0.4"
-bdk_coin_select = "0.4.1"
+bitcoin-coin-selection = { version = "0.7.3", features = ["rand"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/wallet/src/silentpayments/sending.rs
+++ b/crates/wallet/src/silentpayments/sending.rs
@@ -2,13 +2,10 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-use bdk_coin_select::metrics::LowestFee;
-use bdk_coin_select::{
-    Candidate, ChangePolicy, CoinSelector, Drain, DrainWeights, Target, TargetFee, TargetOutputs,
-};
+use bitcoin_coin_selection::{single_random_draw, WeightedUtxo};
+
 use bitcoin::hashes::Hash;
 use bitcoin::key::TweakedPublicKey;
-use bitcoin::secp256k1::rand::seq::SliceRandom;
 use bitcoin::secp256k1::{self, Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey};
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::transaction::Version;
@@ -21,8 +18,6 @@ use silentpayments::utils::sending::calculate_partial_secret;
 use silentpayments::{Network, SilentPaymentAddress};
 
 use crate::silentpayments::wallet::{Coin, Wallet};
-
-const LONG_TERM_FEERATE_SAT_PER_VB: f32 = 1.0;
 
 #[derive(Debug)]
 pub enum SendError {
@@ -132,6 +127,19 @@ fn bitcoin_network(network: Network) -> bitcoin::Network {
     }
 }
 
+impl WeightedUtxo for SpendableCoin<'_> {
+    fn satisfaction_weight(&self) -> Weight {
+        // see rust-bitcoin InputWeightPrediction P2TR_KEY_DEFAULT_SIGHASH
+        // for full calculation, see InputWeightPrediction::from_slice()
+        // 1 witness_len + 1 item len +  64 signature
+        Weight::from_wu(66)
+    }
+
+    fn value(&self) -> Amount {
+        self.coin.value
+    }
+}
+
 struct SpendableCoin<'a> {
     outpoint: OutPoint,
     coin: &'a Coin,
@@ -173,99 +181,21 @@ impl Wallet {
 fn build_transaction(
     spend_secret: &SecretKey,
     recipient: Recipient,
-    amount: Amount,
+    target_amount: Amount,
     fee_rate: FeeRate,
     tip_height: u32,
     change_address: SilentPaymentAddress,
     coins: &[SpendableCoin],
 ) -> Result<Transaction, SendError> {
-    if coins.is_empty() {
-        return Err(SendError::NoSpendableCoins);
-    }
-    let secp = Secp256k1::signing_only();
+    let selection = single_random_draw(target_amount, fee_rate, coins);
 
-    let recipient_script = match &recipient {
-        Recipient::Address(address) => Some(address.script_pubkey()),
-        Recipient::SilentPayment(_) => None,
-    };
-    let recipient_dust = match &recipient_script {
-        Some(spk) => spk.minimal_non_dust(),
-        None => p2tr_dust(spend_secret, &secp),
-    };
-    if amount < recipient_dust {
-        return Err(SendError::DustAmount {
-            amount,
-            dust: recipient_dust,
-        });
-    }
-    let change_dust = p2tr_dust(spend_secret, &secp);
-    let recipient_weight = match &recipient_script {
-        Some(spk) => output_weight(spk.len()).to_wu(),
-        None => DrainWeights::TR_KEYSPEND.output_weight,
-    };
-
-    let feerate = cs_feerate(fee_rate);
-    let target = Target {
-        fee: TargetFee::from_feerate(feerate),
-        outputs: TargetOutputs::fund_outputs([(recipient_weight, amount.to_sat())]),
-    };
-    let change_policy = ChangePolicy::min_value_and_waste(
-        DrainWeights::TR_KEYSPEND,
-        change_dust.to_sat(),
-        feerate,
-        bdk_coin_select::FeeRate::from_sat_per_vb(LONG_TERM_FEERATE_SAT_PER_VB),
-    );
-
-    let (mut selected, drain) = select_coins(coins, target, change_policy, 100_000)?;
-    let mut rng = bitcoin::secp256k1::rand::thread_rng();
-    selected.shuffle(&mut rng);
-
-    let signing_keys: Vec<SecretKey> = selected
-        .iter()
-        .map(|c| spend_secret.add_tweak(&c.coin.tweak))
-        .collect::<Result<_, secp256k1::Error>>()?;
-
-    let change_value = drain.is_some().then(|| Amount::from_sat(drain.value));
-    let recipient_is_sp = matches!(recipient, Recipient::SilentPayment(_));
-    let derived: HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>> = if recipient_is_sp
-        || change_value.is_some()
-    {
-        // true marks each key as taproot since every silent payment coin is a P2TR output
-        let input_keys: Vec<(SecretKey, bool)> = signing_keys.iter().map(|k| (*k, true)).collect();
-        let outpoints: Vec<(String, u32)> = selected
-            .iter()
-            .map(|c| (c.outpoint.txid.to_string(), c.outpoint.vout))
-            .collect();
-        let partial_secret = calculate_partial_secret(&input_keys, &outpoints)?;
-        let mut sp_addrs = Vec::new();
-        if let Recipient::SilentPayment(sp) = &recipient {
-            sp_addrs.push(*sp);
-        }
-        if change_value.is_some() {
-            sp_addrs.push(change_address);
-        }
-        generate_recipient_pubkeys(sp_addrs, partial_secret)?
+    let utxo_selection = if let Some((_i, utxos)) = selection {
+        utxos
     } else {
-        HashMap::new()
+        return Err(SendError::NoSpendableCoins);
     };
 
-    let recipient_script = match recipient {
-        Recipient::Address(address) => address.script_pubkey(),
-        Recipient::SilentPayment(sp) => sp_output_script(&derived, sp)?,
-    };
-    let mut output = vec![TxOut {
-        value: amount,
-        script_pubkey: recipient_script,
-    }];
-    if let Some(value) = change_value {
-        output.push(TxOut {
-            value,
-            script_pubkey: sp_output_script(&derived, change_address)?,
-        });
-    }
-    output.shuffle(&mut rng);
-
-    let input: Vec<TxIn> = selected
+    let input: Vec<TxIn> = utxo_selection
         .iter()
         .map(|c| TxIn {
             previous_output: c.outpoint,
@@ -275,6 +205,56 @@ fn build_transaction(
         })
         .collect();
 
+    let utxo_sum: Amount = utxo_selection.iter().map(|u| u.value()).sum();
+    let fee_total: Amount = utxo_selection
+        .iter()
+        .map(|u| u.calculate_fee(fee_rate).unwrap())
+        .sum();
+
+    let secp = Secp256k1::signing_only();
+    let signing_keys: Vec<SecretKey> = utxo_selection
+        .iter()
+        .map(|c| spend_secret.add_tweak(&c.coin.tweak))
+        .collect::<Result<_, secp256k1::Error>>()?;
+
+    let change_value: Amount = utxo_sum - target_amount - fee_total;
+
+    let mut output = vec![];
+    // true marks each key as taproot since every silent payment coin is a P2TR output
+    let input_keys: Vec<(SecretKey, bool)> = signing_keys.iter().map(|k| (*k, true)).collect();
+
+    let outpoints: Vec<(String, u32)> = utxo_selection
+        .iter()
+        .map(|c| (c.outpoint.txid.to_string(), c.outpoint.vout))
+        .collect();
+
+    let partial_secret = calculate_partial_secret(&input_keys, &outpoints)?;
+    let mut sp_addrs = Vec::new();
+    if let Recipient::SilentPayment(sp) = &recipient {
+        sp_addrs.push(*sp);
+    }
+    sp_addrs.push(change_address);
+    let derived = generate_recipient_pubkeys(sp_addrs, partial_secret)?;
+
+    let recipient_script = match recipient {
+        Recipient::Address(ref address) => address.script_pubkey(),
+        Recipient::SilentPayment(sp) => sp_output_script(&derived, sp)?,
+    };
+
+    let recipient_output = TxOut {
+        value: target_amount,
+        script_pubkey: recipient_script,
+    };
+
+    output.push(recipient_output);
+
+    let change_output = TxOut {
+        value: change_value,
+        script_pubkey: sp_output_script(&derived, change_address)?,
+    };
+
+    output.push(change_output);
+
     let mut tx = Transaction {
         version: Version::TWO,
         lock_time: LockTime::from_height(tip_height).unwrap_or(LockTime::ZERO),
@@ -282,7 +262,7 @@ fn build_transaction(
         output,
     };
 
-    let prevouts: Vec<TxOut> = selected
+    let prevouts: Vec<TxOut> = utxo_selection
         .iter()
         .map(|c| TxOut {
             value: c.coin.value,
@@ -292,7 +272,7 @@ fn build_transaction(
 
     debug_assert_eq!(signing_keys.len(), prevouts.len());
     let mut cache = SighashCache::new(&tx);
-    let mut witnesses = Vec::with_capacity(selected.len());
+    let mut witnesses = Vec::with_capacity(utxo_selection.len());
     for (i, signing_key) in signing_keys.iter().enumerate() {
         let sighash = cache.taproot_key_spend_signature_hash(
             i,
@@ -315,51 +295,6 @@ fn build_transaction(
     Ok(tx)
 }
 
-fn select_coins<'a, 'c>(
-    coins: &'c [SpendableCoin<'a>],
-    target: Target,
-    change_policy: ChangePolicy,
-    max_bnb_rounds: usize,
-) -> Result<(Vec<&'c SpendableCoin<'a>>, Drain), SendError> {
-    let spendable: Vec<&SpendableCoin> = coins.iter().collect();
-    let candidates: Vec<Candidate> = spendable
-        .iter()
-        .map(|c| Candidate::new_tr_keyspend(c.coin.value.to_sat()))
-        .collect();
-
-    let mut selector = CoinSelector::new(&candidates);
-    let metric = LowestFee {
-        target,
-        long_term_feerate: bdk_coin_select::FeeRate::from_sat_per_vb(LONG_TERM_FEERATE_SAT_PER_VB),
-        change_policy,
-    };
-    if selector.run_bnb(metric, max_bnb_rounds).is_err() {
-        selector.sort_candidates_by_descending_value_pwu();
-        selector.select_until_target_met(target).map_err(|e| {
-            let available = coins
-                .iter()
-                .map(|c| c.coin.value.to_sat())
-                .fold(0u64, u64::saturating_add);
-            SendError::InsufficientFunds {
-                needed: Amount::from_sat(available.saturating_add(e.missing)),
-                available: Amount::from_sat(available),
-            }
-        })?;
-    }
-    let drain = selector.drain(target, change_policy);
-    let selected = selector.apply_selection(&spendable).copied().collect();
-    Ok((selected, drain))
-}
-
-fn cs_feerate(fee_rate: FeeRate) -> bdk_coin_select::FeeRate {
-    bdk_coin_select::FeeRate::from_sat_per_wu(fee_rate.to_sat_per_kwu() as f32 / 1000.0)
-}
-
-fn output_weight(script_len: usize) -> Weight {
-    // 8-byte value, 1-byte length prefix, then the script, times 4 weight units per byte.
-    Weight::from_wu_usize((8 + 1 + script_len) * 4)
-}
-
 fn sp_output_script(
     derived: &HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>,
     address: SilentPaymentAddress,
@@ -373,11 +308,6 @@ fn sp_output_script(
 
 fn p2tr_script(output_key: XOnlyPublicKey) -> ScriptBuf {
     ScriptBuf::new_p2tr_tweaked(TweakedPublicKey::dangerous_assume_tweaked(output_key))
-}
-
-fn p2tr_dust(spend_secret: &SecretKey, secp: &Secp256k1<secp256k1::SignOnly>) -> Amount {
-    let probe = spend_secret.x_only_public_key(secp).0;
-    p2tr_script(probe).minimal_non_dust()
 }
 
 #[cfg(test)]
@@ -439,7 +369,7 @@ mod tests {
         let recipient = address(even_secret([0x03; 32]), even_secret([0x04; 32]));
 
         let tweak = Scalar::from_be_bytes([0x05; 32]).unwrap();
-        let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(100_000));
+        let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(101_000));
         let outpoint = OutPoint {
             txid: Txid::from_byte_array([0xab; 32]),
             vout: 0,
@@ -515,7 +445,7 @@ mod tests {
             &coins,
         )
         .unwrap_err();
-        assert!(matches!(err, SendError::InsufficientFunds { .. }));
+        assert!(matches!(err, SendError::NoSpendableCoins));
     }
 
     #[test]
@@ -528,7 +458,7 @@ mod tests {
             .unwrap();
 
         let tweak = Scalar::from_be_bytes([0x05; 32]).unwrap();
-        let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(100_000));
+        let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(101_000));
         let outpoint = OutPoint {
             txid: Txid::from_byte_array([0xab; 32]),
             vout: 0,
@@ -560,7 +490,7 @@ mod tests {
             .unwrap();
 
         let tweak = Scalar::from_be_bytes([0x05; 32]).unwrap();
-        let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(100_000));
+        let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(101_000));
         let outpoint = OutPoint {
             txid: Txid::from_byte_array([0xab; 32]),
             vout: 0,
@@ -586,100 +516,6 @@ mod tests {
         assert!(wallet
             .build_transaction(Recipient::SilentPayment(recipient), amount, fee_rate)
             .is_ok());
-    }
-
-    #[test]
-    fn fallback_selects_largest_first() {
-        let spend_secret = even_secret([0x02; 32]);
-        let owned: Vec<(OutPoint, Coin)> = [30_000u64, 20_000, 10_000, 5_000]
-            .iter()
-            .enumerate()
-            .map(|(i, value)| {
-                let tweak = Scalar::from_be_bytes([i as u8 + 1; 32]).unwrap();
-                let outpoint = OutPoint {
-                    txid: Txid::from_byte_array([0xab; 32]),
-                    vout: i as u32,
-                };
-                (
-                    outpoint,
-                    owned_coin(&spend_secret, tweak, Amount::from_sat(*value)),
-                )
-            })
-            .collect();
-        let coins: Vec<SpendableCoin> = owned
-            .iter()
-            .map(|(outpoint, coin)| SpendableCoin {
-                outpoint: *outpoint,
-                coin,
-            })
-            .collect();
-
-        let amount = Amount::from_sat(45_000);
-        let target = Target {
-            fee: TargetFee::from_feerate(cs_feerate(FeeRate::from_sat_per_vb(2).unwrap())),
-            outputs: TargetOutputs::fund_outputs([(
-                DrainWeights::TR_KEYSPEND.output_weight,
-                amount.to_sat(),
-            )]),
-        };
-        let change_policy = ChangePolicy::min_value(DrainWeights::TR_KEYSPEND, 330);
-
-        // max_bnb_rounds = 0 skips branch and bound, forcing the largest-first fallback.
-        let (selected, _) = select_coins(&coins, target, change_policy, 0).unwrap();
-
-        let mut values: Vec<u64> = selected.iter().map(|c| c.coin.value.to_sat()).collect();
-        values.sort_unstable();
-        assert_eq!(values, vec![20_000, 30_000]);
-    }
-
-    #[test]
-    fn absorbs_uneconomical_change_at_high_feerate() {
-        let secp = Secp256k1::new();
-        let scan_secret = even_secret([0x01; 32]);
-        let spend_secret = even_secret([0x02; 32]);
-        let change_address = build_receiver(
-            &scan_secret,
-            spend_secret.public_key(&secp),
-            Network::Regtest,
-        )
-        .unwrap()
-        .get_change_address();
-        let recipient = address(even_secret([0x03; 32]), even_secret([0x04; 32]));
-
-        let owned: Vec<Coin> = [55_000u64, 30_000, 20_000]
-            .iter()
-            .enumerate()
-            .map(|(i, value)| {
-                let tweak = Scalar::from_be_bytes([i as u8 + 1; 32]).unwrap();
-                owned_coin(&spend_secret, tweak, Amount::from_sat(*value))
-            })
-            .collect();
-        let coins: Vec<SpendableCoin> = owned
-            .iter()
-            .enumerate()
-            .map(|(i, coin)| SpendableCoin {
-                outpoint: OutPoint {
-                    txid: Txid::from_byte_array([0xab; 32]),
-                    vout: i as u32,
-                },
-                coin,
-            })
-            .collect();
-
-        let tx = build_transaction(
-            &spend_secret,
-            Recipient::SilentPayment(recipient),
-            Amount::from_sat(50_000),
-            FeeRate::from_sat_per_vb(30).unwrap(),
-            0,
-            change_address,
-            &coins,
-        )
-        .unwrap();
-
-        assert_eq!(tx.input.len(), 1);
-        assert_eq!(tx.output.len(), 1);
-        assert_eq!(tx.output[0].value, Amount::from_sat(50_000));
     }
 
     #[test]
@@ -710,7 +546,7 @@ mod tests {
                 .unwrap();
 
             let tweak = Scalar::from_be_bytes([0x05; 32]).unwrap();
-            let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(100_000));
+            let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(101_000));
             wallet.utxos.insert(
                 OutPoint {
                     txid: Txid::from_byte_array([0xab; 32]),

--- a/crates/wallet/src/silentpayments/sending.rs
+++ b/crates/wallet/src/silentpayments/sending.rs
@@ -218,6 +218,8 @@ fn build_transaction(
         .collect::<Result<_, secp256k1::Error>>()?;
 
     let change_value: Amount = utxo_sum - target_amount - fee_total;
+    // see CHANGE_LOWER of 50k sats in bitcoin-core,
+    debug_assert!(change_value.to_sat() >= 50_000);
 
     let mut output = vec![];
     // true marks each key as taproot since every silent payment coin is a P2TR output


### PR DESCRIPTION
I wanted to draft this instead of https://github.com/kernel-node/kernel-node/pull/68

Uses `SRD` which doesn't require knowledge of `long_term_fee_rate` or `cost_of_change` and is suitable for testing.  Can follow up with another PR to add `BnB` and `CoinGrinder` once we have more parameters.

If this looks ok, will do some cleanup and remove from draft state.