### PR TITLE
peer: forward a reorg's competing branch to the kernel

### DIFF
--- a/src/peer.rs
+++ b/src/peer.rs
@@ -288,11 +288,18 @@ pub fn process_message(
                     }
                 }
 
-                // If all to be expected blocks were received, clear any
-                // remaining blocks in the buffer and request a fresh batch of
-                // blocks.
+                // All expected blocks have arrived. Flush anything left in the
+                // buffer to the kernel and request the next batch. The leftovers
+                // are a competing branch from a reorg.
                 if block_state.peer_inventory.is_empty() {
-                    block_state.block_buffer.clear();
+                    let leftovers: Vec<_> =
+                        block_state.block_buffer.drain().map(|(_, b)| b).collect();
+                    for leftover in leftovers {
+                        if let Err(err) = node_state.block_tx.send(leftover) {
+                            debug!(target: Category::NODE, "Encountered error on block send: {}", err);
+                            return (PeerStateMachine::AwaitingBlock(block_state), vec![]);
+                        }
+                    }
                     let locators = build_block_locators(node_state.chainman.active_chain().tip());
                     (
                         PeerStateMachine::AwaitingInv,


### PR DESCRIPTION
The block buffer only forwarded blocks that extended the active tip and discarded the rest when the batch finished. A reorg's competing branch forks below the tip, so it never matched and was thrown away, leaving the node stuck on a stale chain. Flush the leftover blocks to the kernel instead, which connects and reorgs them. Normal in-order delivery is unchanged.

Addresses #69 