### PR TITLE
keys: add cli for address recovery

### DIFF
--- a/doc/wallet.md
+++ b/doc/wallet.md
@@ -16,6 +16,11 @@ Generate keys to an output file:
 cargo run --bin cli wallet generate-keys --out keys.bin
 ```
 
+Recover scan PrivateKey and spend PublicKey from file:
+```
+cargo run --bin cli wallet print-keys-from-keys-file keys.bin
+```
+
 ## Starting the daemon
 
 Using the keys file that was generated in the previous step, you can start `kernel-node` and scan for payments with these keys. Note that `--sp-keys-file` requires a fully qualified path for use with the `daemon` option. For example (`/home/me/some_directory/keys.bin`).

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -69,6 +69,9 @@ enum WalletCmd {
         /// 32-byte x-only spend public key as hex.
         spend_key: String,
     },
+    PrintKeysFromKeysFile {
+        path: PathBuf,
+    },
     /// Show wallet balance.
     Balance,
     /// Show wallet transaction history.
@@ -141,6 +144,18 @@ fn main() {
         return;
     }
 
+    if let Commands::Wallet(WalletCmd::PrintKeysFromKeysFile { path }) = &cli.commands {
+        let read = SilentPaymentKeysFile::load(path)
+            .expect("file path provided should be readable as a silent payments keys file");
+
+        let spend_pub = read.spend_xonly();
+        eprintln!("spend_pub={}", spend_pub);
+
+        let scan_priv = read.scan_key;
+        eprintln!("scan_key={}", scan_priv.display_secret());
+        return;
+    }
+
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -174,6 +189,9 @@ fn main() {
                 let client = wallet_response.get().unwrap().get_wallet().unwrap();
                 match cmd {
                     WalletCmd::GenerateKeys { .. } => unreachable!("handled before runtime"),
+                    WalletCmd::PrintKeysFromKeysFile { .. } => {
+                        unreachable!("handled before runtime")
+                    }
                     WalletCmd::ImportKeys {
                         scan_key,
                         spend_key,


### PR DESCRIPTION
I forgot to write down the pub key after generation.  Thought there should be a way to go back and print it again later..

Also, it seems to me, the keys-file stuff should just be it's own crate under `/crates` that does the key generation and recovery.  That way, there isn't the need for the early `return`.