### PR TITLE
silent payments: use select coins algo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,19 +81,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
 ]
-
-[[package]]
-name = "bdk_coin_select"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43064fa3dd1d3a8b24079cfcb5ede6b785857edc782277f17a1736511ccc1916"
 
 [[package]]
 name = "bech32"
@@ -109,16 +108,16 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
+ "arbitrary",
  "base58ck",
  "bech32 0.11.1",
- "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
@@ -134,16 +133,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-coin-selection"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "dca5195aef0ef160aeb2d5ea60ae7b1f1e106a32b8d6af7bdffdd1a4eae532c0"
+dependencies = [
+ "bitcoin",
+ "rand",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-p2p"
@@ -155,11 +179,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals",
+ "arbitrary",
+ "bitcoin-consensus-encoding",
 ]
 
 [[package]]
@@ -173,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
@@ -562,6 +587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,7 +890,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "rand",
  "secp256k1-sys",
 ]
@@ -1137,8 +1171,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 name = "wallet"
 version = "0.1.0"
 dependencies = [
- "bdk_coin_select",
  "bitcoin",
+ "bitcoin-coin-selection",
  "bitcoinkernel",
  "log",
  "silentpayments",

--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -6,5 +6,5 @@ interface Wallet {
     getHistory  @2 () -> (entries :Text);
     receive     @3 () -> (address :Text);
     broadcastRawTx @4 (tx :Data) -> (txid :Text);
-    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64, consolidateFeeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
+    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64, consolidateFeeRateSatPerVb :Float64, discardFeeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
 }

--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -6,5 +6,5 @@ interface Wallet {
     getHistory  @2 () -> (entries :Text);
     receive     @3 () -> (address :Text);
     broadcastRawTx @4 (tx :Data) -> (txid :Text);
-    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
+    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64, longTermFeeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
 }

--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -6,5 +6,5 @@ interface Wallet {
     getHistory  @2 () -> (entries :Text);
     receive     @3 () -> (address :Text);
     broadcastRawTx @4 (tx :Data) -> (txid :Text);
-    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64, longTermFeeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
+    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64, consolidateFeeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
 }

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -8,7 +8,7 @@ silentpayments = { version = "0.5", features = ["receiving", "encode", "sending"
 bitcoin = { version = "0.32.8", features = ["rand-std"] }
 bitcoinkernel = "0.2"
 log = "0.4"
-bdk_coin_select = "0.4.1"
+bitcoin-coin-selection = { version = "0.9", features = ["rand"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/wallet/src/silentpayments/sending.rs
+++ b/crates/wallet/src/silentpayments/sending.rs
@@ -22,8 +22,6 @@ use silentpayments::{Network, SilentPaymentAddress};
 
 use crate::silentpayments::wallet::{Coin, Wallet};
 
-const LONG_TERM_FEERATE_SAT_PER_VB: f32 = 1.0;
-
 #[derive(Debug)]
 pub enum SendError {
     WatchOnly,
@@ -143,6 +141,7 @@ impl Wallet {
         recipient: Recipient,
         amount: Amount,
         fee_rate: FeeRate,
+        long_term_fee_rate: FeeRate,
     ) -> Result<Transaction, SendError> {
         let spend_secret = self.spend_secret.ok_or(SendError::WatchOnly)?;
         let keys = self.keys.as_ref().ok_or(SendError::WatchOnly)?;
@@ -163,6 +162,7 @@ impl Wallet {
             recipient,
             amount,
             fee_rate,
+            long_term_fee_rate,
             self.scan_height,
             change_address,
             &coins,
@@ -170,11 +170,13 @@ impl Wallet {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_transaction(
     spend_secret: &SecretKey,
     recipient: Recipient,
     amount: Amount,
     fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
     tip_height: u32,
     change_address: SilentPaymentAddress,
     coins: &[SpendableCoin],
@@ -213,10 +215,11 @@ fn build_transaction(
         DrainWeights::TR_KEYSPEND,
         change_dust.to_sat(),
         feerate,
-        bdk_coin_select::FeeRate::from_sat_per_vb(LONG_TERM_FEERATE_SAT_PER_VB),
+        bdk_coin_select::FeeRate::from_sat_per_vb(long_term_fee_rate.to_sat_per_vb_ceil() as f32),
     );
 
-    let (mut selected, drain) = select_coins(coins, target, change_policy, 100_000)?;
+    let (mut selected, drain) =
+        select_coins(coins, target, change_policy, long_term_fee_rate, 100_000)?;
     let mut rng = bitcoin::secp256k1::rand::thread_rng();
     selected.shuffle(&mut rng);
 
@@ -319,6 +322,7 @@ fn select_coins<'a, 'c>(
     coins: &'c [SpendableCoin<'a>],
     target: Target,
     change_policy: ChangePolicy,
+    long_term_fee_rate: FeeRate,
     max_bnb_rounds: usize,
 ) -> Result<(Vec<&'c SpendableCoin<'a>>, Drain), SendError> {
     let spendable: Vec<&SpendableCoin> = coins.iter().collect();
@@ -330,7 +334,9 @@ fn select_coins<'a, 'c>(
     let mut selector = CoinSelector::new(&candidates);
     let metric = LowestFee {
         target,
-        long_term_feerate: bdk_coin_select::FeeRate::from_sat_per_vb(LONG_TERM_FEERATE_SAT_PER_VB),
+        long_term_feerate: bdk_coin_select::FeeRate::from_sat_per_vb(
+            long_term_fee_rate.to_sat_per_vb_ceil() as f32,
+        ),
         change_policy,
     };
     if selector.run_bnb(metric, max_bnb_rounds).is_err() {
@@ -450,12 +456,14 @@ mod tests {
         }];
 
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let long_term_fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
         let amount = Amount::from_sat(50_000);
         let tx = build_transaction(
             &spend_secret,
             Recipient::SilentPayment(recipient),
             amount,
             fee_rate,
+            long_term_fee_rate,
             100,
             change_address,
             &coins,
@@ -510,6 +518,7 @@ mod tests {
             Recipient::SilentPayment(recipient),
             Amount::from_sat(20_000),
             FeeRate::from_sat_per_vb(2).unwrap(),
+            FeeRate::from_sat_per_vb(10).unwrap(),
             100,
             change_address,
             &coins,
@@ -540,12 +549,22 @@ mod tests {
         let amount = Amount::from_sat(50_000);
 
         let tx = wallet
-            .build_transaction(Recipient::SilentPayment(recipient), amount, fee_rate)
+            .build_transaction(
+                Recipient::SilentPayment(recipient),
+                amount,
+                fee_rate,
+                fee_rate,
+            )
             .unwrap();
         wallet.reserve_coins(tx.input.iter().map(|i| i.previous_output));
 
         let err = wallet
-            .build_transaction(Recipient::SilentPayment(recipient), amount, fee_rate)
+            .build_transaction(
+                Recipient::SilentPayment(recipient),
+                amount,
+                fee_rate,
+                fee_rate,
+            )
             .unwrap_err();
         assert!(matches!(err, SendError::NoSpendableCoins));
     }
@@ -572,19 +591,34 @@ mod tests {
         let amount = Amount::from_sat(50_000);
 
         let tx = wallet
-            .build_transaction(Recipient::SilentPayment(recipient), amount, fee_rate)
+            .build_transaction(
+                Recipient::SilentPayment(recipient),
+                amount,
+                fee_rate,
+                fee_rate,
+            )
             .unwrap();
         let outpoints: Vec<_> = tx.input.iter().map(|i| i.previous_output).collect();
 
         wallet.reserve_coins(outpoints.iter().copied());
         assert!(matches!(
-            wallet.build_transaction(Recipient::SilentPayment(recipient), amount, fee_rate),
+            wallet.build_transaction(
+                Recipient::SilentPayment(recipient),
+                amount,
+                fee_rate,
+                fee_rate
+            ),
             Err(SendError::NoSpendableCoins)
         ));
 
         wallet.release_coins(outpoints);
         assert!(wallet
-            .build_transaction(Recipient::SilentPayment(recipient), amount, fee_rate)
+            .build_transaction(
+                Recipient::SilentPayment(recipient),
+                amount,
+                fee_rate,
+                fee_rate
+            )
             .is_ok());
     }
 
@@ -615,8 +649,9 @@ mod tests {
             .collect();
 
         let amount = Amount::from_sat(45_000);
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let target = Target {
-            fee: TargetFee::from_feerate(cs_feerate(FeeRate::from_sat_per_vb(2).unwrap())),
+            fee: TargetFee::from_feerate(cs_feerate(fee_rate)),
             outputs: TargetOutputs::fund_outputs([(
                 DrainWeights::TR_KEYSPEND.output_weight,
                 amount.to_sat(),
@@ -625,7 +660,7 @@ mod tests {
         let change_policy = ChangePolicy::min_value(DrainWeights::TR_KEYSPEND, 330);
 
         // max_bnb_rounds = 0 skips branch and bound, forcing the largest-first fallback.
-        let (selected, _) = select_coins(&coins, target, change_policy, 0).unwrap();
+        let (selected, _) = select_coins(&coins, target, change_policy, fee_rate, 0).unwrap();
 
         let mut values: Vec<u64> = selected.iter().map(|c| c.coin.value.to_sat()).collect();
         values.sort_unstable();
@@ -670,6 +705,7 @@ mod tests {
             &spend_secret,
             Recipient::SilentPayment(recipient),
             Amount::from_sat(50_000),
+            FeeRate::from_sat_per_vb(30).unwrap(),
             FeeRate::from_sat_per_vb(30).unwrap(),
             0,
             change_address,
@@ -726,6 +762,7 @@ mod tests {
                     Recipient::Address(addr),
                     amount,
                     FeeRate::from_sat_per_vb(2).unwrap(),
+                    FeeRate::from_sat_per_vb(10).unwrap(),
                 )
                 .unwrap_or_else(|e| panic!("{kind}: {e}"));
 
@@ -753,6 +790,7 @@ mod tests {
             Recipient::SilentPayment(recipient),
             Amount::from_sat(1_000),
             FeeRate::from_sat_per_vb(2).unwrap(),
+            FeeRate::from_sat_per_vb(10).unwrap(),
             100,
             change_address,
             &[],

--- a/crates/wallet/src/silentpayments/sending.rs
+++ b/crates/wallet/src/silentpayments/sending.rs
@@ -2,13 +2,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-use bdk_coin_select::metrics::LowestFee;
-use bdk_coin_select::{
-    Candidate, ChangePolicy, CoinSelector, Drain, DrainWeights, Target, TargetFee, TargetOutputs,
-};
 use bitcoin::hashes::Hash;
 use bitcoin::key::TweakedPublicKey;
-use bitcoin::secp256k1::rand::seq::SliceRandom;
 use bitcoin::secp256k1::{self, Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey};
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::transaction::Version;
@@ -16,11 +11,32 @@ use bitcoin::{
     absolute::LockTime, taproot, Address, Amount, FeeRate, OutPoint, ScriptBuf, Sequence,
     Transaction, TxIn, TxOut, Weight, Witness,
 };
+use bitcoin_coin_selection::{select_coins, WeightedUtxo};
 use silentpayments::sending::generate_recipient_pubkeys;
 use silentpayments::utils::sending::calculate_partial_secret;
 use silentpayments::{Network, SilentPaymentAddress};
 
 use crate::silentpayments::wallet::{Coin, Wallet};
+
+// 32 byte txid, 4 byte output index, 1 byte scriptSig, and 4 byte sequence
+const BASE_WEIGHT: Weight = Weight::from_vb_unwrap(32 + 4 + 1 + 4);
+
+// cost of change is the creation and destruction cost of the change output.
+//
+// therefore, cost_of_change =
+//      (change output size * effective feerate) +
+//      (size of change output * discard feerate)
+//
+// params
+//  * fee_rate - current effective feerate.
+//  * discard_fee_rate - target feerate is feerate with which output will not be a dust output.
+//    ref: core PR# 10817
+fn default_tr_cost_of_change(fee_rate: FeeRate, discard_fee_rate: FeeRate) -> Amount {
+    // output_size is 57.5 vB
+    // the base_weight is 41 vB while the P2TR key-path is 66 WU
+    let output_size = BASE_WEIGHT + Weight::from_wu(66);
+    (output_size * fee_rate) + (output_size * discard_fee_rate)
+}
 
 #[derive(Debug)]
 pub enum SendError {
@@ -135,6 +151,18 @@ struct SpendableCoin<'a> {
     coin: &'a Coin,
 }
 
+impl WeightedUtxo for SpendableCoin<'_> {
+    fn satisfaction_weight(&self) -> Weight {
+        // see rust-bitcoin InputWeightPrediction P2TR_KEY_DEFAULT_SIGHASH
+        // for full calculation, see InputWeightPrediction::from_slice()
+        // 1 witness_len + 1 item len +  64 signature
+        Weight::from_wu(66)
+    }
+    fn value(&self) -> Amount {
+        self.coin.value
+    }
+}
+
 impl Wallet {
     pub fn build_transaction(
         &self,
@@ -142,6 +170,7 @@ impl Wallet {
         amount: Amount,
         fee_rate: FeeRate,
         long_term_fee_rate: FeeRate,
+        discard_fee_rate: FeeRate,
     ) -> Result<Transaction, SendError> {
         let spend_secret = self.spend_secret.ok_or(SendError::WatchOnly)?;
         let keys = self.keys.as_ref().ok_or(SendError::WatchOnly)?;
@@ -163,6 +192,7 @@ impl Wallet {
             amount,
             fee_rate,
             long_term_fee_rate,
+            discard_fee_rate,
             self.scan_height,
             change_address,
             &coins,
@@ -170,20 +200,22 @@ impl Wallet {
     }
 }
 
+fn create_change_output(change_value: Amount, cost_of_change: Amount) -> bool {
+    change_value > cost_of_change
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_transaction(
     spend_secret: &SecretKey,
     recipient: Recipient,
-    amount: Amount,
+    target: Amount,
     fee_rate: FeeRate,
     long_term_fee_rate: FeeRate,
+    discard_fee_rate: FeeRate,
     tip_height: u32,
     change_address: SilentPaymentAddress,
     coins: &[SpendableCoin],
 ) -> Result<Transaction, SendError> {
-    if coins.is_empty() {
-        return Err(SendError::NoSpendableCoins);
-    }
     let secp = Secp256k1::signing_only();
 
     let recipient_script = match &recipient {
@@ -194,44 +226,36 @@ fn build_transaction(
         Some(spk) => spk.minimal_non_dust(),
         None => p2tr_dust(spend_secret, &secp),
     };
-    if amount < recipient_dust {
+    if target < recipient_dust {
         return Err(SendError::DustAmount {
-            amount,
+            amount: target,
             dust: recipient_dust,
         });
     }
-    let change_dust = p2tr_dust(spend_secret, &secp);
-    let recipient_weight = match &recipient_script {
-        Some(spk) => output_weight(spk.len()).to_wu(),
-        None => DrainWeights::TR_KEYSPEND.output_weight,
-    };
 
-    let feerate = cs_feerate(fee_rate);
-    let target = Target {
-        fee: TargetFee::from_feerate(feerate),
-        outputs: TargetOutputs::fund_outputs([(recipient_weight, amount.to_sat())]),
+    let cost_of_change = default_tr_cost_of_change(fee_rate, discard_fee_rate);
+    let selection = select_coins(target, cost_of_change, fee_rate, long_term_fee_rate, coins);
+    let selected = if let Some((_i, utxos)) = selection {
+        utxos
+    } else {
+        return Err(SendError::NoSpendableCoins);
     };
-    let change_policy = ChangePolicy::min_value_and_waste(
-        DrainWeights::TR_KEYSPEND,
-        change_dust.to_sat(),
-        feerate,
-        bdk_coin_select::FeeRate::from_sat_per_vb(long_term_fee_rate.to_sat_per_vb_ceil() as f32),
-    );
-
-    let (mut selected, drain) =
-        select_coins(coins, target, change_policy, long_term_fee_rate, 100_000)?;
-    let mut rng = bitcoin::secp256k1::rand::thread_rng();
-    selected.shuffle(&mut rng);
 
     let signing_keys: Vec<SecretKey> = selected
         .iter()
         .map(|c| spend_secret.add_tweak(&c.coin.tweak))
         .collect::<Result<_, secp256k1::Error>>()?;
 
-    let change_value = drain.is_some().then(|| Amount::from_sat(drain.value));
+    let selected_sum: Amount = selected.iter().map(|u| u.value()).sum();
+    let fee_total = selected
+        .iter()
+        .map(|u| u.calculate_fee(fee_rate).unwrap())
+        .sum();
+    let change_value: Amount = selected_sum - target - fee_total;
+
     let recipient_is_sp = matches!(recipient, Recipient::SilentPayment(_));
     let derived: HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>> = if recipient_is_sp
-        || change_value.is_some()
+        || create_change_output(change_value, cost_of_change)
     {
         // true marks each key as taproot since every silent payment coin is a P2TR output
         let input_keys: Vec<(SecretKey, bool)> = signing_keys.iter().map(|k| (*k, true)).collect();
@@ -244,7 +268,7 @@ fn build_transaction(
         if let Recipient::SilentPayment(sp) = &recipient {
             sp_addrs.push(*sp);
         }
-        if change_value.is_some() {
+        if create_change_output(change_value, cost_of_change) {
             sp_addrs.push(change_address);
         }
         generate_recipient_pubkeys(sp_addrs, partial_secret)?
@@ -257,16 +281,15 @@ fn build_transaction(
         Recipient::SilentPayment(sp) => sp_output_script(&derived, sp)?,
     };
     let mut output = vec![TxOut {
-        value: amount,
+        value: target,
         script_pubkey: recipient_script,
     }];
-    if let Some(value) = change_value {
+    if create_change_output(change_value, cost_of_change) {
         output.push(TxOut {
-            value,
+            value: change_value,
             script_pubkey: sp_output_script(&derived, change_address)?,
         });
     }
-    output.shuffle(&mut rng);
 
     let input: Vec<TxIn> = selected
         .iter()
@@ -316,54 +339,6 @@ fn build_transaction(
     }
 
     Ok(tx)
-}
-
-fn select_coins<'a, 'c>(
-    coins: &'c [SpendableCoin<'a>],
-    target: Target,
-    change_policy: ChangePolicy,
-    long_term_fee_rate: FeeRate,
-    max_bnb_rounds: usize,
-) -> Result<(Vec<&'c SpendableCoin<'a>>, Drain), SendError> {
-    let spendable: Vec<&SpendableCoin> = coins.iter().collect();
-    let candidates: Vec<Candidate> = spendable
-        .iter()
-        .map(|c| Candidate::new_tr_keyspend(c.coin.value.to_sat()))
-        .collect();
-
-    let mut selector = CoinSelector::new(&candidates);
-    let metric = LowestFee {
-        target,
-        long_term_feerate: bdk_coin_select::FeeRate::from_sat_per_vb(
-            long_term_fee_rate.to_sat_per_vb_ceil() as f32,
-        ),
-        change_policy,
-    };
-    if selector.run_bnb(metric, max_bnb_rounds).is_err() {
-        selector.sort_candidates_by_descending_value_pwu();
-        selector.select_until_target_met(target).map_err(|e| {
-            let available = coins
-                .iter()
-                .map(|c| c.coin.value.to_sat())
-                .fold(0u64, u64::saturating_add);
-            SendError::InsufficientFunds {
-                needed: Amount::from_sat(available.saturating_add(e.missing)),
-                available: Amount::from_sat(available),
-            }
-        })?;
-    }
-    let drain = selector.drain(target, change_policy);
-    let selected = selector.apply_selection(&spendable).copied().collect();
-    Ok((selected, drain))
-}
-
-fn cs_feerate(fee_rate: FeeRate) -> bdk_coin_select::FeeRate {
-    bdk_coin_select::FeeRate::from_sat_per_wu(fee_rate.to_sat_per_kwu() as f32 / 1000.0)
-}
-
-fn output_weight(script_len: usize) -> Weight {
-    // 8-byte value, 1-byte length prefix, then the script, times 4 weight units per byte.
-    Weight::from_wu_usize((8 + 1 + script_len) * 4)
 }
 
 fn sp_output_script(
@@ -457,6 +432,7 @@ mod tests {
 
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let long_term_fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
+        let discard_fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
         let amount = Amount::from_sat(50_000);
         let tx = build_transaction(
             &spend_secret,
@@ -464,6 +440,7 @@ mod tests {
             amount,
             fee_rate,
             long_term_fee_rate,
+            discard_fee_rate,
             100,
             change_address,
             &coins,
@@ -519,12 +496,13 @@ mod tests {
             Amount::from_sat(20_000),
             FeeRate::from_sat_per_vb(2).unwrap(),
             FeeRate::from_sat_per_vb(10).unwrap(),
+            FeeRate::from_sat_per_vb(10).unwrap(),
             100,
             change_address,
             &coins,
         )
         .unwrap_err();
-        assert!(matches!(err, SendError::InsufficientFunds { .. }));
+        assert!(matches!(err, SendError::NoSpendableCoins));
     }
 
     #[test]
@@ -546,6 +524,7 @@ mod tests {
 
         let recipient = address(even_secret([0x03; 32]), even_secret([0x04; 32]));
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let discard_fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let amount = Amount::from_sat(50_000);
 
         let tx = wallet
@@ -554,6 +533,7 @@ mod tests {
                 amount,
                 fee_rate,
                 fee_rate,
+                discard_fee_rate,
             )
             .unwrap();
         wallet.reserve_coins(tx.input.iter().map(|i| i.previous_output));
@@ -564,6 +544,7 @@ mod tests {
                 amount,
                 fee_rate,
                 fee_rate,
+                discard_fee_rate,
             )
             .unwrap_err();
         assert!(matches!(err, SendError::NoSpendableCoins));
@@ -588,6 +569,7 @@ mod tests {
 
         let recipient = address(even_secret([0x03; 32]), even_secret([0x04; 32]));
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let discard_fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let amount = Amount::from_sat(50_000);
 
         let tx = wallet
@@ -596,6 +578,7 @@ mod tests {
                 amount,
                 fee_rate,
                 fee_rate,
+                discard_fee_rate,
             )
             .unwrap();
         let outpoints: Vec<_> = tx.input.iter().map(|i| i.previous_output).collect();
@@ -606,7 +589,8 @@ mod tests {
                 Recipient::SilentPayment(recipient),
                 amount,
                 fee_rate,
-                fee_rate
+                fee_rate,
+                discard_fee_rate
             ),
             Err(SendError::NoSpendableCoins)
         ));
@@ -617,54 +601,10 @@ mod tests {
                 Recipient::SilentPayment(recipient),
                 amount,
                 fee_rate,
-                fee_rate
+                fee_rate,
+                discard_fee_rate
             )
             .is_ok());
-    }
-
-    #[test]
-    fn fallback_selects_largest_first() {
-        let spend_secret = even_secret([0x02; 32]);
-        let owned: Vec<(OutPoint, Coin)> = [30_000u64, 20_000, 10_000, 5_000]
-            .iter()
-            .enumerate()
-            .map(|(i, value)| {
-                let tweak = Scalar::from_be_bytes([i as u8 + 1; 32]).unwrap();
-                let outpoint = OutPoint {
-                    txid: Txid::from_byte_array([0xab; 32]),
-                    vout: i as u32,
-                };
-                (
-                    outpoint,
-                    owned_coin(&spend_secret, tweak, Amount::from_sat(*value)),
-                )
-            })
-            .collect();
-        let coins: Vec<SpendableCoin> = owned
-            .iter()
-            .map(|(outpoint, coin)| SpendableCoin {
-                outpoint: *outpoint,
-                coin,
-            })
-            .collect();
-
-        let amount = Amount::from_sat(45_000);
-        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
-        let target = Target {
-            fee: TargetFee::from_feerate(cs_feerate(fee_rate)),
-            outputs: TargetOutputs::fund_outputs([(
-                DrainWeights::TR_KEYSPEND.output_weight,
-                amount.to_sat(),
-            )]),
-        };
-        let change_policy = ChangePolicy::min_value(DrainWeights::TR_KEYSPEND, 330);
-
-        // max_bnb_rounds = 0 skips branch and bound, forcing the largest-first fallback.
-        let (selected, _) = select_coins(&coins, target, change_policy, fee_rate, 0).unwrap();
-
-        let mut values: Vec<u64> = selected.iter().map(|c| c.coin.value.to_sat()).collect();
-        values.sort_unstable();
-        assert_eq!(values, vec![20_000, 30_000]);
     }
 
     #[test]
@@ -707,6 +647,7 @@ mod tests {
             Amount::from_sat(50_000),
             FeeRate::from_sat_per_vb(30).unwrap(),
             FeeRate::from_sat_per_vb(30).unwrap(),
+            FeeRate::from_sat_per_vb(30).unwrap(),
             0,
             change_address,
             &coins,
@@ -746,7 +687,7 @@ mod tests {
                 .unwrap();
 
             let tweak = Scalar::from_be_bytes([0x05; 32]).unwrap();
-            let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(100_000));
+            let coin = owned_coin(&spend_secret, tweak, Amount::from_sat(101_000));
             wallet.utxos.insert(
                 OutPoint {
                     txid: Txid::from_byte_array([0xab; 32]),
@@ -762,6 +703,7 @@ mod tests {
                     Recipient::Address(addr),
                     amount,
                     FeeRate::from_sat_per_vb(2).unwrap(),
+                    FeeRate::from_sat_per_vb(10).unwrap(),
                     FeeRate::from_sat_per_vb(10).unwrap(),
                 )
                 .unwrap_or_else(|e| panic!("{kind}: {e}"));
@@ -790,6 +732,7 @@ mod tests {
             Recipient::SilentPayment(recipient),
             Amount::from_sat(1_000),
             FeeRate::from_sat_per_vb(2).unwrap(),
+            FeeRate::from_sat_per_vb(10).unwrap(),
             FeeRate::from_sat_per_vb(10).unwrap(),
             100,
             change_address,

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -93,6 +93,13 @@ enum WalletCmd {
         /// pool can be reduced (default: 10 sats/vB).  Long term fee rate,
         /// in satoshis per virtual byte.  Defaults to fee_rate if not supplied.
         consolidate_fee_rate_sat_per_vb: Option<f64>,
+        /// The fee rate (in %s/kvB) that indicates your tolerance for
+        /// discarding change by adding it to the fee (default: %s).
+        ///
+        /// Note: An output is discarded if it is dust at this rate, but we will
+        /// always discard up to the dust relay fee and a discard fee above that
+        /// is limited by the fee estimate for the longest target.
+        discard_fee_rate_sat_per_vb: Option<f64>,
     },
 }
 
@@ -239,6 +246,7 @@ fn main() {
                         amount_sat,
                         fee_rate_sat_per_vb,
                         consolidate_fee_rate_sat_per_vb,
+                        discard_fee_rate_sat_per_vb,
                     } => {
                         let mut req = client.send_to_address_request();
                         req.get().set_address(&address);
@@ -250,6 +258,12 @@ fn main() {
                                 .set_consolidate_fee_rate_sat_per_vb(consolidate_fee_rate);
                         } else {
                             req.get().set_consolidate_fee_rate_sat_per_vb(10.0);
+                        }
+
+                        if let Some(discard_fee_rate) = discard_fee_rate_sat_per_vb {
+                            req.get().set_discard_fee_rate_sat_per_vb(discard_fee_rate);
+                        } else {
+                            req.get().set_discard_fee_rate_sat_per_vb(10.0);
                         }
 
                         let result = req.send().promise.await.unwrap();

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -88,6 +88,9 @@ enum WalletCmd {
         amount_sat: u64,
         /// Fee rate, in satoshis per virtual byte.
         fee_rate_sat_per_vb: f64,
+        /// Long term fee rate, in satoshis per virtual byte.  Defaults to fee_rate if not
+        /// supplied.
+        long_term_fee_rate_sat_per_vb: Option<f64>,
     },
 }
 
@@ -233,11 +236,20 @@ fn main() {
                         address,
                         amount_sat,
                         fee_rate_sat_per_vb,
+                        long_term_fee_rate_sat_per_vb,
                     } => {
                         let mut req = client.send_to_address_request();
                         req.get().set_address(&address);
                         req.get().set_amount_sat(amount_sat);
                         req.get().set_fee_rate_sat_per_vb(fee_rate_sat_per_vb);
+
+                        if let Some(lt_fee_rate) = long_term_fee_rate_sat_per_vb {
+                            req.get().set_long_term_fee_rate_sat_per_vb(lt_fee_rate);
+                        } else {
+                            req.get()
+                                .set_long_term_fee_rate_sat_per_vb(fee_rate_sat_per_vb);
+                        }
+
                         let result = req.send().promise.await.unwrap();
                         let r = result.get().unwrap();
                         let message = r.get_message().unwrap().to_string().unwrap();

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -88,9 +88,11 @@ enum WalletCmd {
         amount_sat: u64,
         /// Fee rate, in satoshis per virtual byte.
         fee_rate_sat_per_vb: f64,
-        /// Long term fee rate, in satoshis per virtual byte.  Defaults to fee_rate if not
-        /// supplied.
-        long_term_fee_rate_sat_per_vb: Option<f64>,
+        /// The maximum feerate in sats/vB at which transaction building may
+        /// use more inputs than strictly necessary so that the wallet's UTXO
+        /// pool can be reduced (default: 10 sats/vB).  Long term fee rate,
+        /// in satoshis per virtual byte.  Defaults to fee_rate if not supplied.
+        consolidate_fee_rate_sat_per_vb: Option<f64>,
     },
 }
 
@@ -236,18 +238,18 @@ fn main() {
                         address,
                         amount_sat,
                         fee_rate_sat_per_vb,
-                        long_term_fee_rate_sat_per_vb,
+                        consolidate_fee_rate_sat_per_vb,
                     } => {
                         let mut req = client.send_to_address_request();
                         req.get().set_address(&address);
                         req.get().set_amount_sat(amount_sat);
                         req.get().set_fee_rate_sat_per_vb(fee_rate_sat_per_vb);
 
-                        if let Some(lt_fee_rate) = long_term_fee_rate_sat_per_vb {
-                            req.get().set_long_term_fee_rate_sat_per_vb(lt_fee_rate);
-                        } else {
+                        if let Some(consolidate_fee_rate) = consolidate_fee_rate_sat_per_vb {
                             req.get()
-                                .set_long_term_fee_rate_sat_per_vb(fee_rate_sat_per_vb);
+                                .set_consolidate_fee_rate_sat_per_vb(consolidate_fee_rate);
+                        } else {
+                            req.get().set_consolidate_fee_rate_sat_per_vb(10.0);
                         }
 
                         let result = req.send().promise.await.unwrap();

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -180,6 +180,7 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         let p = params.get()?;
         let address = p.get_address()?.to_string()?;
         let amount = Amount::from_sat(p.get_amount_sat());
+
         let fee_rate_sat_per_vb = p.get_fee_rate_sat_per_vb();
         if !fee_rate_sat_per_vb.is_finite() || fee_rate_sat_per_vb < 0.0 {
             return Err(capnp::Error::failed(
@@ -188,9 +189,20 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         }
         // 250 sat/kwu equals 1 sat/vB, rounded up so the rate is never below what was asked
         let fee_rate = FeeRate::from_sat_per_kwu((fee_rate_sat_per_vb * 250.0).ceil() as u64);
+
+        let long_term_fee_rate_sat_per_vb = p.get_long_term_fee_rate_sat_per_vb();
+        if !long_term_fee_rate_sat_per_vb.is_finite() || long_term_fee_rate_sat_per_vb < 0.0 {
+            return Err(capnp::Error::failed(
+                "long term fee rate must be a non-negative number".to_string(),
+            ));
+        }
+        let long_term_fee_rate =
+            FeeRate::from_sat_per_kwu((long_term_fee_rate_sat_per_vb * 250.0).ceil() as u64);
+
         let mut wallet = self.state.lock().unwrap();
-        let build = Recipient::parse(&address, wallet.network)
-            .and_then(|recipient| wallet.build_transaction(recipient, amount, fee_rate));
+        let build = Recipient::parse(&address, wallet.network).and_then(|recipient| {
+            wallet.build_transaction(recipient, amount, fee_rate, long_term_fee_rate)
+        });
         let tx = match build {
             Ok(tx) => tx,
             Err(e) if e.is_user_error() => {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -190,7 +190,7 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         // 250 sat/kwu equals 1 sat/vB, rounded up so the rate is never below what was asked
         let fee_rate = FeeRate::from_sat_per_kwu((fee_rate_sat_per_vb * 250.0).ceil() as u64);
 
-        let long_term_fee_rate_sat_per_vb = p.get_long_term_fee_rate_sat_per_vb();
+        let long_term_fee_rate_sat_per_vb = p.get_consolidate_fee_rate_sat_per_vb();
         if !long_term_fee_rate_sat_per_vb.is_finite() || long_term_fee_rate_sat_per_vb < 0.0 {
             return Err(capnp::Error::failed(
                 "long term fee rate must be a non-negative number".to_string(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -199,9 +199,24 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         let long_term_fee_rate =
             FeeRate::from_sat_per_kwu((long_term_fee_rate_sat_per_vb * 250.0).ceil() as u64);
 
+        let discard_fee_rate_sat_per_vb = p.get_discard_fee_rate_sat_per_vb();
+        if !discard_fee_rate_sat_per_vb.is_finite() || discard_fee_rate_sat_per_vb < 0.0 {
+            return Err(capnp::Error::failed(
+                "discard fee rate must be a non-negative number".to_string(),
+            ));
+        }
+        let discard_fee_rate =
+            FeeRate::from_sat_per_kwu((discard_fee_rate_sat_per_vb * 250.0).ceil() as u64);
+
         let mut wallet = self.state.lock().unwrap();
         let build = Recipient::parse(&address, wallet.network).and_then(|recipient| {
-            wallet.build_transaction(recipient, amount, fee_rate, long_term_fee_rate)
+            wallet.build_transaction(
+                recipient,
+                amount,
+                fee_rate,
+                long_term_fee_rate,
+                discard_fee_rate,
+            )
         });
         let tx = match build {
             Ok(tx) => tx,


### PR DESCRIPTION
High level overview of this PR:
 
* Add discard_fee_rate to cli.
* Use select_coins function to make selection from rust-bitcoin-coin-selection lib

As a follow up, it would be nice to internally estimate both FeeRate and LongTermFeeRate using mempool and blockchain data similar to bitcoin core 