### PR TITLE
units: use u32 for fee rate

### DIFF
--- a/capnp/wallet.capnp
+++ b/capnp/wallet.capnp
@@ -6,5 +6,5 @@ interface Wallet {
     getHistory  @2 () -> (entries :Text);
     receive     @3 () -> (address :Text);
     broadcastRawTx @4 (tx :Data) -> (txid :Text);
-    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :Float64) -> (ok :Bool, message :Text);
+    sendToAddress @5 (address :Text, amountSat :UInt64, feeRateSatPerVb :UInt32) -> (ok :Bool, message :Text);
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -87,7 +87,7 @@ enum WalletCmd {
         /// Amount to send, in satoshis.
         amount_sat: u64,
         /// Fee rate, in satoshis per virtual byte.
-        fee_rate_sat_per_vb: f64,
+        fee_rate_sat_per_vb: u32,
     },
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -181,13 +181,8 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         let address = p.get_address()?.to_string()?;
         let amount = Amount::from_sat(p.get_amount_sat());
         let fee_rate_sat_per_vb = p.get_fee_rate_sat_per_vb();
-        if !fee_rate_sat_per_vb.is_finite() || fee_rate_sat_per_vb < 0.0 {
-            return Err(capnp::Error::failed(
-                "fee rate must be a non-negative number".to_string(),
-            ));
-        }
         // 250 sat/kwu equals 1 sat/vB, rounded up so the rate is never below what was asked
-        let fee_rate = FeeRate::from_sat_per_kwu((fee_rate_sat_per_vb * 250.0).ceil() as u64);
+        let fee_rate = FeeRate::from_sat_per_kwu(fee_rate_sat_per_vb * 250);
         let mut wallet = self.state.lock().unwrap();
         let build = Recipient::parse(&address, wallet.network)
             .and_then(|recipient| wallet.build_transaction(recipient, amount, fee_rate));

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -181,8 +181,7 @@ impl wallet_capnp::wallet::Server for WalletIpcInterface {
         let address = p.get_address()?.to_string()?;
         let amount = Amount::from_sat(p.get_amount_sat());
         let fee_rate_sat_per_vb = p.get_fee_rate_sat_per_vb();
-        // 250 sat/kwu equals 1 sat/vB, rounded up so the rate is never below what was asked
-        let fee_rate = FeeRate::from_sat_per_kwu(fee_rate_sat_per_vb * 250);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(fee_rate_sat_per_vb);
         let mut wallet = self.state.lock().unwrap();
         let build = Recipient::parse(&address, wallet.network)
             .and_then(|recipient| wallet.build_transaction(recipient, amount, fee_rate));


### PR DESCRIPTION
Use u32 to represent fee_rate since rust-bitcoin internally uses a `u64` to represent a fee-rate.  This also helps avoid a panic that can happen while multiplying by 250.  Also, may as well use rust-bitcoin to do the conversion from vB to kwu.