### PR TITLE
Add wallet CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "bdk_coin_select",
  "bitcoin",
  "bitcoinkernel",
+ "clap",
  "log",
  "silentpayments",
  "tempfile",

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -9,6 +9,10 @@ bitcoin = { version = "0.32.8", features = ["rand-std"] }
 bitcoinkernel = "0.2"
 log = "0.4"
 bdk_coin_select = "0.4.1"
+clap = { version = "4", features = ["derive"]  }
 
 [dev-dependencies]
 tempfile = "3"
+
+[[bin]]
+name = "cli"

--- a/crates/wallet/src/bin/cli.rs
+++ b/crates/wallet/src/bin/cli.rs
@@ -33,9 +33,8 @@ enum WalletCmd {
         #[arg(long)]
         out: Option<PathBuf>,
     },
-    PrintKeysFromKeysFile {
-        path: PathBuf,
-    },
+    /// Print scan_key, spend_priv and spend_pub keys to stdout from file.
+    PrintKeysFromKeysFile { path: PathBuf },
 }
 
 fn main() {

--- a/crates/wallet/src/bin/cli.rs
+++ b/crates/wallet/src/bin/cli.rs
@@ -48,33 +48,33 @@ fn main() {
         (scan_priv, spend_priv, spend_xonly)
     }
 
-    if let Commands::Wallet(WalletCmd::GenerateKeys { out }) = &cli.commands {
-        let (scan_priv, spend_priv, spend_pub) = generate_keys();
-        match out {
-            Some(path) => {
-                let file = SilentPaymentKeysFile::new(scan_priv, SpendKey::Secret(spend_priv));
-                file.save(path).expect("failed to write keys file");
-                eprintln!("Wrote silent payment keys to {}", path.display());
-                eprintln!("spend_pub={}", spend_pub);
-            }
-            None => {
-                eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
-                println!("scan_key={}", scan_priv.display_secret());
-                println!("spend_priv={}", spend_priv.display_secret());
-                println!("spend_pub={}", spend_pub);
+    match cli.commands {
+        Commands::Wallet(WalletCmd::GenerateKeys { out }) => {
+            let (scan_priv, spend_priv, spend_pub) = generate_keys();
+            match out {
+                Some(path) => {
+                    let file = SilentPaymentKeysFile::new(scan_priv, SpendKey::Secret(spend_priv));
+                    file.save(&path).expect("failed to write keys file");
+                    eprintln!("Wrote silent payment keys to {}", path.display());
+                    eprintln!("spend_pub={}", spend_pub);
+                }
+                None => {
+                    eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
+                    println!("scan_key={}", scan_priv.display_secret());
+                    println!("spend_priv={}", spend_priv.display_secret());
+                    println!("spend_pub={}", spend_pub);
+                }
             }
         }
-    }
+        Commands::Wallet(WalletCmd::PrintKeysFromKeysFile { path }) => {
+            let read = SilentPaymentKeysFile::load(&path)
+                .expect("file path provided should be readable as a silent payments keys file");
 
-    if let Commands::Wallet(WalletCmd::PrintKeysFromKeysFile { path }) = &cli.commands {
-        let read = SilentPaymentKeysFile::load(path)
-            .expect("file path provided should be readable as a silent payments keys file");
+            let spend_pub = read.spend_xonly();
+            eprintln!("spend_pub={}", spend_pub);
 
-        let spend_pub = read.spend_xonly();
-        eprintln!("spend_pub={}", spend_pub);
-
-        let scan_priv = read.scan_key;
-        eprintln!("scan_key={}", scan_priv.display_secret());
-        return;
+            let scan_priv = read.scan_key;
+            eprintln!("scan_key={}", scan_priv.display_secret());
+        }
     }
 }

--- a/crates/wallet/src/bin/cli.rs
+++ b/crates/wallet/src/bin/cli.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use bitcoin::secp256k1::{rand::rngs::OsRng, Secp256k1, SecretKey, XOnlyPublicKey};
+use clap::Parser;
+use wallet::io::FileExt;
+use wallet::silentpayments::{SilentPaymentKeysFile, SpendKey};
+
+#[derive(clap::Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    commands: Commands,
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+enum Commands {
+    /// Wallet commands.
+    #[command(subcommand)]
+    Wallet(WalletCmd),
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+enum WalletCmd {
+    /// Generate fresh scan and spend keys for receiving silent payments.
+    ///
+    /// By default, prints the scan key, spend private key, and spend
+    /// x-only public key as hex on stdout. With `--out <path>`, writes
+    /// the secrets to a binary file and prints only the spend public
+    /// key on stderr. WARNING: anyone with the scan key and spend
+    /// private key can spend received funds.
+    GenerateKeys {
+        /// Write the keys to this binary file. Must not already exist.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+    PrintKeysFromKeysFile {
+        path: PathBuf,
+    },
+}
+
+fn main() {
+    let cli = Args::parse();
+
+    fn generate_keys() -> (SecretKey, SecretKey, XOnlyPublicKey) {
+        let secp = Secp256k1::new();
+        let scan_priv = SecretKey::new(&mut OsRng);
+        let spend_priv = SecretKey::new(&mut OsRng);
+        let (spend_xonly, _) = spend_priv.public_key(&secp).x_only_public_key();
+        (scan_priv, spend_priv, spend_xonly)
+    }
+
+    if let Commands::Wallet(WalletCmd::GenerateKeys { out }) = &cli.commands {
+        let (scan_priv, spend_priv, spend_pub) = generate_keys();
+        match out {
+            Some(path) => {
+                let file = SilentPaymentKeysFile::new(scan_priv, SpendKey::Secret(spend_priv));
+                file.save(path).expect("failed to write keys file");
+                eprintln!("Wrote silent payment keys to {}", path.display());
+                eprintln!("spend_pub={}", spend_pub);
+            }
+            None => {
+                eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
+                println!("scan_key={}", scan_priv.display_secret());
+                println!("spend_priv={}", spend_priv.display_secret());
+                println!("spend_pub={}", spend_pub);
+            }
+        }
+    }
+
+    if let Commands::Wallet(WalletCmd::PrintKeysFromKeysFile { path }) = &cli.commands {
+        let read = SilentPaymentKeysFile::load(path)
+            .expect("file path provided should be readable as a silent payments keys file");
+
+        let spend_pub = read.spend_xonly();
+        eprintln!("spend_pub={}", spend_pub);
+
+        let scan_priv = read.scan_key;
+        eprintln!("scan_key={}", scan_priv.display_secret());
+        return;
+    }
+}

--- a/doc/wallet.md
+++ b/doc/wallet.md
@@ -6,19 +6,21 @@
 
 A silent payment address is comprised of two elliptic curve keypairs, known as a "scan key" and "spend key." To generate these two keys and optionally save them to a file, one may use the CLI. Note that a running instance of `kernel-node` is _not_ required for this step.
 
+Please note, key generation is done by the wallet, not the node, so first switch to the wallet directory.
+
 Generate keys in memory and print them to the console:
 ```
-cargo run --bin cli wallet generate-keys
+cd crates/wallet && cargo run --bin cli wallet generate-keys
 ```
 
 Generate keys to an output file:
 ```
-cargo run --bin cli wallet generate-keys --out keys.bin
+cd crates/wallet && cargo run --bin cli wallet generate-keys --out keys.bin
 ```
 
 Recover scan PrivateKey and spend PublicKey from file:
 ```
-cargo run --bin cli wallet print-keys-from-keys-file keys.bin
+cd crates/wallet && cargo run --bin cli wallet print-keys-from-keys-file keys.bin
 ```
 
 ## Starting the daemon

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,14 +1,9 @@
-use std::path::PathBuf;
-
 use bitcoin::hex::FromHex;
-use bitcoin::secp256k1::{rand::rngs::OsRng, Secp256k1, SecretKey, XOnlyPublicKey};
 use clap::Parser;
 use kernel_node::ext::DirnameExt;
 use kernel_node::server_capnp::server;
 use tokio::net::UnixStream;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-use wallet::io::FileExt;
-use wallet::silentpayments::{SilentPaymentKeysFile, SpendKey};
 
 const DEFAULT_DATA_DIR: &str = "~/.kernel-node/";
 
@@ -45,20 +40,28 @@ struct Echo {
     message: String,
 }
 
+async fn connect_server(datadir_path: &str) -> server::Client {
+    let sock_file = datadir_path.to_owned() + "/node.sock";
+    let stream = UnixStream::connect(&sock_file)
+        .await
+        .expect("Could not connect to node.sock. Is `node` running?");
+    let (reader, writer) = stream.into_split();
+    let buf_reader = futures::io::BufReader::new(reader.compat());
+    let buf_writer = futures::io::BufWriter::new(writer.compat_write());
+    let network = capnp_rpc::twoparty::VatNetwork::new(
+        buf_reader,
+        buf_writer,
+        capnp_rpc::rpc_twoparty_capnp::Side::Client,
+        Default::default(),
+    );
+    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
+    let client: server::Client = rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+    tokio::task::spawn_local(rpc_system);
+    client
+}
+
 #[derive(Debug, Clone, clap::Subcommand)]
 enum WalletCmd {
-    /// Generate fresh scan and spend keys for receiving silent payments.
-    ///
-    /// By default, prints the scan key, spend private key, and spend
-    /// x-only public key as hex on stdout. With `--out <path>`, writes
-    /// the secrets to a binary file and prints only the spend public
-    /// key on stderr. WARNING: anyone with the scan key and spend
-    /// private key can spend received funds.
-    GenerateKeys {
-        /// Write the keys to this binary file. Must not already exist.
-        #[arg(long)]
-        out: Option<PathBuf>,
-    },
     /// Import BIP-352 silent payment keys to enable scanning for incoming payments.
     ///
     /// Both keys are hex-encoded. The scan key derives the ECDH shared secret with
@@ -68,9 +71,6 @@ enum WalletCmd {
         scan_key: String,
         /// 32-byte x-only spend public key as hex.
         spend_key: String,
-    },
-    PrintKeysFromKeysFile {
-        path: PathBuf,
     },
     /// Show wallet balance.
     Balance,
@@ -94,67 +94,8 @@ enum WalletCmd {
     },
 }
 
-fn generate_keys() -> (SecretKey, SecretKey, XOnlyPublicKey) {
-    let secp = Secp256k1::new();
-    let scan_priv = SecretKey::new(&mut OsRng);
-    let spend_priv = SecretKey::new(&mut OsRng);
-    let (spend_xonly, _) = spend_priv.public_key(&secp).x_only_public_key();
-    (scan_priv, spend_priv, spend_xonly)
-}
-
-async fn connect_server(datadir_path: &str) -> server::Client {
-    let sock_file = datadir_path.to_owned() + "/node.sock";
-    let stream = UnixStream::connect(&sock_file)
-        .await
-        .expect("Could not connect to node.sock. Is `node` running?");
-    let (reader, writer) = stream.into_split();
-    let buf_reader = futures::io::BufReader::new(reader.compat());
-    let buf_writer = futures::io::BufWriter::new(writer.compat_write());
-    let network = capnp_rpc::twoparty::VatNetwork::new(
-        buf_reader,
-        buf_writer,
-        capnp_rpc::rpc_twoparty_capnp::Side::Client,
-        Default::default(),
-    );
-    let mut rpc_system = capnp_rpc::RpcSystem::new(Box::new(network), None);
-    let client: server::Client = rpc_system.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
-    tokio::task::spawn_local(rpc_system);
-    client
-}
-
 fn main() {
     let cli = Args::parse();
-
-    if let Commands::Wallet(WalletCmd::GenerateKeys { out }) = &cli.commands {
-        let (scan_priv, spend_priv, spend_pub) = generate_keys();
-        match out {
-            Some(path) => {
-                let file = SilentPaymentKeysFile::new(scan_priv, SpendKey::Secret(spend_priv));
-                file.save(path).expect("failed to write keys file");
-                eprintln!("Wrote silent payment keys to {}", path.display());
-                eprintln!("spend_pub={}", spend_pub);
-            }
-            None => {
-                eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");
-                println!("scan_key={}", scan_priv.display_secret());
-                println!("spend_priv={}", spend_priv.display_secret());
-                println!("spend_pub={}", spend_pub);
-            }
-        }
-        return;
-    }
-
-    if let Commands::Wallet(WalletCmd::PrintKeysFromKeysFile { path }) = &cli.commands {
-        let read = SilentPaymentKeysFile::load(path)
-            .expect("file path provided should be readable as a silent payments keys file");
-
-        let spend_pub = read.spend_xonly();
-        eprintln!("spend_pub={}", spend_pub);
-
-        let scan_priv = read.scan_key;
-        eprintln!("scan_key={}", scan_priv.display_secret());
-        return;
-    }
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -188,10 +129,6 @@ fn main() {
                 let wallet_response = client.make_wallet_request().send().promise.await.unwrap();
                 let client = wallet_response.get().unwrap().get_wallet().unwrap();
                 match cmd {
-                    WalletCmd::GenerateKeys { .. } => unreachable!("handled before runtime"),
-                    WalletCmd::PrintKeysFromKeysFile { .. } => {
-                        unreachable!("handled before runtime")
-                    }
                     WalletCmd::ImportKeys {
                         scan_key,
                         spend_key,


### PR DESCRIPTION
Remove commands from node cli which would otherwise require an early return and are `unreachable`.  Logically these commands belong to wallet, so create wallet cli, and move commands to be under wallet instead of node.

Also, I think this would make the wallet more extensible in that we could start adding more key types and functionality.