### PR TITLE
docs: add doc comment for PrintKeysFromKeysFile

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -69,9 +69,8 @@ enum WalletCmd {
         /// 32-byte x-only spend public key as hex.
         spend_key: String,
     },
-    PrintKeysFromKeysFile {
-        path: PathBuf,
-    },
+    /// Print scan_key, spend_priv and spend_pub keys to stdout from file.
+    PrintKeysFromKeysFile { path: PathBuf },
     /// Show wallet balance.
     Balance,
     /// Show wallet transaction history.


### PR DESCRIPTION
Apologies, it appears I missed this doc comment when adding.

Might be worth adding a lint to warn when doc comments are missing.