### PR TITLE
cli: replace eprintln with println

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -131,8 +131,8 @@ fn main() {
             Some(path) => {
                 let file = SilentPaymentKeysFile::new(scan_priv, SpendKey::Secret(spend_priv));
                 file.save(path).expect("failed to write keys file");
-                eprintln!("Wrote silent payment keys to {}", path.display());
-                eprintln!("spend_pub={}", spend_pub);
+                println!("Wrote silent payment keys to {}", path.display());
+                println!("spend_pub={}", spend_pub);
             }
             None => {
                 eprintln!("WARNING: scan_key and spend_priv must be kept secret — anyone with them can spend received funds.");


### PR DESCRIPTION
eprintln is generally reserved for error messaging