### PR TITLE
node: Add a getTip RPC for the chain tip

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), configure_me_codegen::Error> {
         .src_prefix("capnp")
         .file("capnp/server.capnp")
         .file("capnp/wallet.capnp")
+        .file("capnp/chain.capnp")
         .run()
         .unwrap();
     configure_me_codegen::build_script_auto()

--- a/capnp/chain.capnp
+++ b/capnp/chain.capnp
@@ -1,0 +1,5 @@
+@0x93074320567c5aeb;
+
+interface Chain {
+    getTip @0 () -> (height :UInt32, hash :Text);
+}

--- a/capnp/server.capnp
+++ b/capnp/server.capnp
@@ -1,9 +1,11 @@
 @0xc2e20cc9503cf68f;
 
 using Wallet = import "wallet.capnp";
+using Chain = import "chain.capnp";
 
 interface Server {
     echo @0 (msg :Text) -> (reply :Text);
     shutdown @1 () -> ();
     makeWallet @2 () -> (wallet :Wallet.Wallet);
+    makeChain @3 () -> (chain :Chain.Chain);
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -34,9 +34,18 @@ enum Commands {
     Echo(Echo),
     /// Terminate the server.
     Stop,
+    /// Chain commands.
+    #[command(subcommand)]
+    Chain(ChainCmd),
     /// Wallet commands.
     #[command(subcommand)]
     Wallet(WalletCmd),
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+enum ChainCmd {
+    /// Show the current chain tip.
+    Tip,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -194,6 +203,20 @@ fn main() {
                 let shutdown_req = client.shutdown_request();
                 shutdown_req.send().promise.await.unwrap();
                 println!("Kernel node stopping...");
+            }
+            Commands::Chain(cmd) => {
+                let chain_response = client.make_chain_request().send().promise.await.unwrap();
+                let client = chain_response.get().unwrap().get_chain().unwrap();
+                match cmd {
+                    ChainCmd::Tip => {
+                        let req = client.get_tip_request();
+                        let result = req.send().promise.await.unwrap();
+                        let r = result.get().unwrap();
+                        let height = r.get_height();
+                        let hash = r.get_hash().unwrap().to_string().unwrap();
+                        println!("height={height} hash={hash}");
+                    }
+                }
             }
             Commands::Wallet(cmd) => {
                 let wallet_response = client.make_wallet_request().send().promise.await.unwrap();

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -660,6 +660,7 @@ fn main() {
     }
 
     let wallet_for_ipc = Arc::clone(&wallet);
+    let chainman_for_ipc = Arc::clone(&node_state.chainman);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -685,6 +686,7 @@ fn main() {
                         };
                         debug!(target: Category::IPC, "Handling inbound IPC call");
                         let state = Arc::clone(&wallet_for_ipc);
+                        let chainman = Arc::clone(&chainman_for_ipc);
                         let (reader, writer) = stream.into_split();
                         let buf_reader = futures::io::BufReader::new(reader.compat());
                         let buf_writer = futures::io::BufWriter::new(writer.compat_write());
@@ -698,6 +700,7 @@ fn main() {
                             ipc_shutdown.clone(),
                             broadcast_tx.clone(),
                             state,
+                            chainman,
                         ));
                         let rpc_system =
                             capnp_rpc::RpcSystem::new(Box::new(network), Some(client.client));

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,17 +1,19 @@
 use std::sync::{mpsc, Arc, Mutex};
 
 use bitcoin::consensus::Decodable;
+use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{SecretKey, XOnlyPublicKey};
-use bitcoin::{Amount, FeeRate, Transaction};
+use bitcoin::{Amount, BlockHash, FeeRate, Transaction};
+use bitcoinkernel::{core::BlockHashExt, ChainstateManager};
 use wallet::silentpayments::{Recipient, Wallet};
 
-use crate::{server_capnp, wallet_capnp};
+use crate::{chain_capnp, server_capnp, wallet_capnp};
 
-#[derive(Debug)]
 pub struct IpcInterface {
     tx: mpsc::Sender<()>,
     broadcast_tx: mpsc::SyncSender<Transaction>,
     state: Arc<Mutex<Wallet>>,
+    chainman: Arc<ChainstateManager>,
 }
 
 impl IpcInterface {
@@ -19,11 +21,13 @@ impl IpcInterface {
         tx: mpsc::Sender<()>,
         broadcast_tx: mpsc::SyncSender<Transaction>,
         state: Arc<Mutex<Wallet>>,
+        chainman: Arc<ChainstateManager>,
     ) -> Self {
         Self {
             tx,
             broadcast_tx,
             state,
+            chainman,
         }
     }
 }
@@ -61,6 +65,44 @@ impl server_capnp::server::Server for IpcInterface {
             self.broadcast_tx.clone(),
         ));
         results.get().set_wallet(client);
+        Ok(())
+    }
+
+    async fn make_chain(
+        self: capnp::capability::Rc<Self>,
+        _: server_capnp::server::MakeChainParams,
+        mut results: server_capnp::server::MakeChainResults,
+    ) -> Result<(), capnp::Error> {
+        let client: chain_capnp::chain::Client =
+            capnp_rpc::new_client(ChainIpcInterface::new(self.chainman.clone()));
+        results.get().set_chain(client);
+        Ok(())
+    }
+}
+
+pub struct ChainIpcInterface {
+    chainman: Arc<ChainstateManager>,
+}
+
+impl ChainIpcInterface {
+    pub fn new(chainman: Arc<ChainstateManager>) -> Self {
+        Self { chainman }
+    }
+}
+
+impl chain_capnp::chain::Server for ChainIpcInterface {
+    async fn get_tip(
+        self: capnp::capability::Rc<Self>,
+        _: chain_capnp::chain::GetTipParams,
+        mut results: chain_capnp::chain::GetTipResults,
+    ) -> Result<(), capnp::Error> {
+        let tip = self.chainman.active_chain().tip();
+        let height = tip.height();
+        let hash = BlockHash::from_byte_array(tip.block_hash().to_bytes());
+
+        let mut r = results.get();
+        r.set_height(height as u32);
+        r.set_hash(hash.to_string());
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,3 +86,4 @@ pub fn resolve_seeds(network: Network) -> Vec<IpAddr> {
 
 capnp::generated_code!(pub mod server_capnp);
 capnp::generated_code!(pub mod wallet_capnp);
+capnp::generated_code!(pub mod chain_capnp);


### PR DESCRIPTION
Nothing on the control socket reports the node's chain position, so tests can see it peer with Bitcoin Core but not that it followed the chain. Add `getTip`, returning the active chain height and best block hash, and a chain tip subcommand to the cli to print them.

Depends on #78 
Followup #86 