### PR TITLE
peer: Move the connection loop into a peer manager

### DIFF
--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     ops::DerefMut,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -27,7 +27,8 @@ use kernel_node::{
     ext::{ChainExt, DirnameExt, NetworkExt},
     ipc::IpcInterface,
     logging::Category,
-    peer::{BitcoinPeer, NodeState, TipState},
+    peer::{NodeState, TipState},
+    peer_manager::PeerManager,
     resolve_seeds,
     server_capnp::server,
     FatalShutdown, ScanEvent,
@@ -266,7 +267,7 @@ fn broadcast_transaction(
 fn run(
     network: Network,
     connect: Option<SocketAddr>,
-    mut node_state: NodeState,
+    node_state: NodeState,
     shutdown_rx: mpsc::Receiver<()>,
     addr_rx: mpsc::Receiver<Vec<AddrV2Message>>,
     block_rx: mpsc::Receiver<bitcoinkernel::Block>,
@@ -323,68 +324,25 @@ fn run(
     let addrman = Arc::new(Mutex::new(table));
     let addrman_for_feelers = Arc::clone(&addrman);
     let wallet_for_broadcast = Arc::clone(&wallet);
+    let node_state = Arc::new(node_state);
 
     let running = Arc::new(AtomicBool::new(true));
     let running_addr = running.clone();
-    let running_peer = running.clone();
     let running_block = running.clone();
     let running_scan = running.clone();
     let running_feelers = running.clone();
 
-    let peer_source = Arc::clone(&addrman);
-    let kill = Arc::new(Mutex::new(None));
-    let writer = Arc::clone(&kill);
-    let stale_block_kill = Arc::clone(&kill);
-
-    let peer_processing_handler = thread::spawn(move || {
-        info!(target: Category::NODE, "Starting net processing thread.");
-        while running_peer.load(Ordering::SeqCst) {
-            let socket_addr = if let Some(addr) = connect {
-                Some(addr)
-            } else {
-                let addr_lock = peer_source.lock().unwrap();
-                let (address, port) = addr_lock.select().unwrap().network_addr();
-                match address {
-                    AddrV2::Ipv4(ipv4) => Some(SocketAddr::V4(SocketAddrV4::new(ipv4, port))),
-                    AddrV2::Ipv6(ipv6) => Some(SocketAddr::from((ipv6, port))),
-                    _ => None,
-                }
-            };
-            let Some(socket_addr) = socket_addr else {
-                continue;
-            };
-            let peer = BitcoinPeer::new(socket_addr, network, &mut node_state);
-            let mut peer = match peer {
-                Ok(connection) => {
-                    let mut writer_lock = writer.lock().unwrap();
-                    *writer_lock = Some(connection.writer());
-                    connection
-                }
-                Err(e) => {
-                    error!(target: Category::NET, "Could not connect: {e}");
-                    std::thread::sleep(Duration::from_millis(500));
-                    continue;
-                }
-            };
-            if !running_peer.load(Ordering::SeqCst) {
-                break;
-            }
-            loop {
-                if let Err(e) = peer.receive_and_process_message(&mut node_state) {
-                    match e {
-                        p2p::net::Error::Io(io) => {
-                            if io.kind() != std::io::ErrorKind::UnexpectedEof {
-                                error!(target: Category::NET, "Unexpected I/O error: {}", io);
-                            }
-                        }
-                        e => error!(target: Category::NET, "Error processing message: {e}"),
-                    }
-                    break;
-                }
-            }
-        }
-        info!(target: Category::NODE, "Stopping net processing thread.");
-    });
+    let mut peer_manager = PeerManager::new(
+        Arc::clone(&addrman),
+        Arc::clone(&node_state),
+        network,
+        fatal.clone(),
+    );
+    if connect.is_some() {
+        peer_manager = peer_manager.max_peers(1);
+    }
+    peer_manager.start();
+    let peer_writers = peer_manager.peer_writers().to_vec();
 
     let addr_processing_handler = thread::spawn(move || {
         info!(target: Category::NODE, "Starting addr processing thread.");
@@ -422,10 +380,11 @@ fn run(
                 Err(RecvTimeoutError::Timeout) => {
                     if last_block.elapsed() > STALE_BLOCK_DURATION {
                         last_block = Instant::now();
-                        info!(target: Category::NET, "Potential stale block. Finding a new peer.");
-                        let mut peer_lock = stale_block_kill.lock().unwrap();
-                        if let Some(conn) = peer_lock.deref_mut() {
-                            let _ = conn.shutdown();
+                        info!(target: Category::NET, "Potential stale block. Dropping peers to find new ones.");
+                        for slot in &peer_writers {
+                            if let Some(conn) = slot.lock().unwrap().deref_mut() {
+                                let _ = conn.shutdown();
+                            }
                         }
                     }
                     continue;
@@ -523,17 +482,14 @@ fn run(
         info!(target: Category::NODE, "Received shutdown signal, shutting down...");
         running.store(false, Ordering::SeqCst);
         context.interrupt().unwrap();
-        let mut peer_lock = kill.lock().unwrap();
-        if let Some(conn) = peer_lock.deref_mut() {
-            conn.shutdown().unwrap()
-        }
+        peer_manager.stop();
     }
 
     addr_processing_handler.join().unwrap();
-    peer_processing_handler.join().unwrap();
     block_processing_handler.join().unwrap();
     scan_processing_handler.join().unwrap();
     feeler_thread.join().unwrap();
+    peer_manager.join();
 
     info!(target: Category::NODE, "Exiting.");
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod daemonize;
 pub mod ext;
 pub mod ipc;
 pub mod peer;
+pub mod peer_manager;
 
 pub mod logging {
     pub struct Category;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -155,7 +155,7 @@ fn create_getdata_message(block_hashes: &[bitcoin::BlockHash]) -> NetworkMessage
 pub fn process_message(
     state_machine: PeerStateMachine,
     event: NetworkMessage,
-    node_state: &mut NodeState,
+    node_state: &NodeState,
 ) -> (PeerStateMachine, Vec<NetworkMessage>) {
     // Always process the ping first as a special case.
     if let NetworkMessage::Ping(nonce) = event {
@@ -334,7 +334,7 @@ impl BitcoinPeer {
     pub fn new(
         socket_addr: SocketAddr,
         network: Network,
-        node_state: &mut NodeState,
+        node_state: &NodeState,
     ) -> Result<Self, p2p::net::Error> {
         let height = node_state.chainman.active_chain().height();
         let conf = ConnectionConfig::new()
@@ -373,7 +373,7 @@ impl BitcoinPeer {
 
     pub fn receive_and_process_message(
         &mut self,
-        node_state: &mut NodeState,
+        node_state: &NodeState,
     ) -> Result<(), p2p::net::Error> {
         let msg = self.receive_message()?;
         let old_state = std::mem::take(&mut self.state_machine);

--- a/src/peer_manager.rs
+++ b/src/peer_manager.rs
@@ -1,0 +1,183 @@
+use std::{
+    collections::HashSet,
+    net::SocketAddr,
+    ops::DerefMut,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    time::Duration,
+};
+
+use bitcoin::{p2p::address::AddrV2, Network};
+use log::{debug, error, info};
+use p2p::net::ConnectionWriter;
+
+use crate::{
+    logging::Category,
+    peer::{BitcoinPeer, NodeState},
+    FatalShutdown,
+};
+
+const TABLE_WIDTH: usize = 16;
+const TABLE_SLOT: usize = 16;
+const MAX_BUCKETS: usize = 4;
+
+pub type AddrTable = addrman::Table<TABLE_WIDTH, TABLE_SLOT, MAX_BUCKETS>;
+
+const DEFAULT_MAX_PEERS: usize = 1;
+
+/// Consecutive one second waits on an empty address book before giving up.
+/// Nothing refills it without a working network, so waiting longer only
+/// hides the problem.
+const EMPTY_ADDRESS_BOOK_LIMIT: u32 = 60;
+
+pub struct PeerManager {
+    max_peers: usize,
+    fatal: FatalShutdown,
+    addrman: Arc<Mutex<AddrTable>>,
+    node_state: Arc<NodeState>,
+    network: Network,
+    running: Arc<AtomicBool>,
+    peer_threads: Vec<thread::JoinHandle<()>>,
+    peer_writers: Vec<Arc<Mutex<Option<Arc<ConnectionWriter>>>>>,
+    connected_peers: Arc<Mutex<HashSet<SocketAddr>>>,
+}
+
+impl PeerManager {
+    pub fn new(
+        addrman: Arc<Mutex<AddrTable>>,
+        node_state: Arc<NodeState>,
+        network: Network,
+        fatal: FatalShutdown,
+    ) -> Self {
+        Self {
+            max_peers: DEFAULT_MAX_PEERS,
+            fatal,
+            addrman,
+            node_state,
+            network,
+            running: Arc::new(AtomicBool::new(true)),
+            peer_threads: Vec::new(),
+            peer_writers: Vec::new(),
+            connected_peers: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub fn max_peers(mut self, n: usize) -> Self {
+        self.max_peers = n.max(1);
+        self
+    }
+
+    pub fn peer_writers(&self) -> &[Arc<Mutex<Option<Arc<ConnectionWriter>>>>] {
+        &self.peer_writers
+    }
+
+    pub fn start(&mut self) {
+        info!(target: Category::NET, "Starting peer manager with {} peers", self.max_peers);
+        for i in 0..self.max_peers {
+            let running = Arc::clone(&self.running);
+            let addrman = Arc::clone(&self.addrman);
+            let node_state = Arc::clone(&self.node_state);
+            let network = self.network;
+            let writer_slot: Arc<Mutex<Option<Arc<ConnectionWriter>>>> = Arc::new(Mutex::new(None));
+            let writer_slot_thread = Arc::clone(&writer_slot);
+            self.peer_writers.push(writer_slot);
+            let connected_peers = Arc::clone(&self.connected_peers);
+            let fatal = self.fatal.clone();
+
+            let handle = thread::spawn(move || {
+                info!(target: Category::NET, "Peer thread {} started", i);
+                let mut empty_selections = 0u32;
+                while running.load(Ordering::SeqCst) {
+                    let selected = {
+                        let table = addrman.lock().unwrap();
+                        table.select().map(|record| record.network_addr())
+                    };
+                    let socket_addr = match selected {
+                        Some((AddrV2::Ipv4(ipv4), port)) => SocketAddr::from((ipv4, port)),
+                        Some((AddrV2::Ipv6(ipv6), port)) => SocketAddr::from((ipv6, port)),
+                        Some(_) => continue,
+                        None => {
+                            empty_selections += 1;
+                            if empty_selections >= EMPTY_ADDRESS_BOOK_LIMIT {
+                                fatal.trigger(
+                                    Category::NET,
+                                    format!(
+                                        "No peer address available for {EMPTY_ADDRESS_BOOK_LIMIT} seconds. \
+                                         DNS seeding likely failed and the network is unreachable."
+                                    ),
+                                );
+                                return;
+                            }
+                            thread::sleep(Duration::from_secs(1));
+                            continue;
+                        }
+                    };
+                    empty_selections = 0;
+
+                    {
+                        let mut connected = connected_peers.lock().unwrap();
+                        if !connected.insert(socket_addr) {
+                            drop(connected);
+                            debug!(target: Category::NET, "Peer thread {}: {} already connected", i, socket_addr);
+                            thread::sleep(Duration::from_secs(1));
+                            continue;
+                        }
+                    }
+
+                    let mut peer = match BitcoinPeer::new(socket_addr, network, &node_state) {
+                        Ok(peer) => {
+                            *writer_slot_thread.lock().unwrap() = Some(peer.writer());
+                            peer
+                        }
+                        Err(e) => {
+                            error!(target: Category::NET, "Peer thread {}: could not connect to {}: {}", i, socket_addr, e);
+                            connected_peers.lock().unwrap().remove(&socket_addr);
+                            thread::sleep(Duration::from_millis(500));
+                            continue;
+                        }
+                    };
+
+                    info!(target: Category::NET, "Peer thread {}: connected to {}", i, peer);
+                    while running.load(Ordering::SeqCst) {
+                        if let Err(e) = peer.receive_and_process_message(&node_state) {
+                            match e {
+                                p2p::net::Error::Io(io)
+                                    if io.kind() == std::io::ErrorKind::UnexpectedEof => {}
+                                p2p::net::Error::Io(io) => {
+                                    error!(target: Category::NET, "Peer thread {}: I/O error: {}", i, io)
+                                }
+                                e => {
+                                    error!(target: Category::NET, "Peer thread {}: error: {}", i, e)
+                                }
+                            }
+                            break;
+                        }
+                    }
+
+                    connected_peers.lock().unwrap().remove(&socket_addr);
+                    *writer_slot_thread.lock().unwrap() = None;
+                }
+                info!(target: Category::NET, "Peer thread {} stopped", i);
+            });
+            self.peer_threads.push(handle);
+        }
+    }
+
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+        for writer_slot in &self.peer_writers {
+            if let Some(conn) = writer_slot.lock().unwrap().deref_mut() {
+                let _ = conn.shutdown();
+            }
+        }
+    }
+
+    pub fn join(self) {
+        for handle in self.peer_threads {
+            let _ = handle.join();
+        }
+    }
+}


### PR DESCRIPTION
The loop runs inline in run(), and the connection writer lives in a shared slot so the stale block check can close it. A second connection would duplicate both. PeerManager owns a thread per connection and exposes the writers. Peer functions take `&NodeState` instead of `&mut NodeState`, since the threads share one. The manager still runs one connection, so behavior is unchanged.